### PR TITLE
Add tool hcidump

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -32,6 +32,7 @@
   <project path="external/apache-http" name="platform/external/apache-http" />
   <project path="external/bluetooth/bluez" name="platform/external/bluetooth/bluez" />
   <project path="external/bluetooth/glib" name="platform/external/bluetooth/glib" />
+  <project path="external/bluetooth/hcidump" name="platform/external/bluetooth/hcidump" />
   <project path="external/bsdiff" name="platform/external/bsdiff" />
   <project path="external/bzip2" name="platform/external/bzip2" />
   <project path="external/dbus" name="platform/external/dbus" />


### PR DESCRIPTION
hcidump is an important tool for debugging/analyzing Bluetooth profile PDU. 
