### PR TITLE
Add librecovery to the otoro manifest

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -24,6 +24,7 @@
   <project path="gecko" name="releases-mozilla-central" remote="mozilla" revision="master" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
+  <project path="librecovery" name="librecovery" remote="b2g" revision="master" />
 
   <!-- Stock Android things -->
   <project path="abi/cpp" name="platform/abi/cpp" />


### PR DESCRIPTION
This needs to be merged **after** my librecovery repository is forked to mozilla-b2g:
http://github.com/marshall/librecovery
