### PR TITLE
SKIA library now points to b2g fork instead of AOSP one

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -62,7 +62,6 @@
   <project path="external/protobuf" name="platform/external/protobuf" />
   <project path="external/safe-iop" name="platform/external/safe-iop" />
   <project path="external/screencap-gonk" name="screencap-gonk" remote="b2g" revision="master" />
-  <project path="external/skia" name="platform/external/skia" />
   <project path="external/sonivox" name="platform/external/sonivox" />
   <project path="external/speex" name="platform/external/speex" />
   <project path="external/sqlite" name="platform/external/sqlite" />
@@ -96,5 +95,6 @@
   <!-- Galaxy S2 things -->
   <project path="device/samsung/galaxys2" name="android-device-galaxys2" remote="b2g" revision="master" />
   <project path="hardware/broadcom/wlan" name="platform/hardware/broadcom/wlan" />
+  <project path="external/skia" name="skia-b2g-sgs2" remote="b2g" revision="master" />
 
 </manifest>


### PR DESCRIPTION
This is needed by the camera fix
