### PR TITLE
Bug 783023: Added orangutan to PandaBoard's external packages

### DIFF
--- a/pandaboard.xml
+++ b/pandaboard.xml
@@ -101,5 +101,6 @@
   <project path="hardware/ti/wlan" name="platform/hardware/ti/wlan" revision="60dfeb6e4448bfed707946ebca6612980f525e69" />
   <project path="hardware/ti/wpan" name="platform/hardware/ti/wpan" revision="3ece7d9e08052989401e008bc397dbcd2557cfd0" />
   <project path="external/negatus" name="Negatus" remote="mozilla" revision="master" />
+  <project path="external/orangutan" name="orangutan" remote="b2g" revision="master" />
 
 </manifest>


### PR DESCRIPTION
The orangutan package provides testing infrastructure for input devices. It
should be available on the PandaBoard by default.

Change-Id: I9d306b13adf7c84f8739f211c221ebf58dcb4c54
Signed-off-by: Thomas Zimmermann tdz@users.sourceforge.net
