### PR TITLE
Change projects of kernel and hardware/qcom/display to caf version on hamachi device.

### DIFF
--- a/hamachi.xml
+++ b/hamachi.xml
@@ -104,7 +104,7 @@
   <project path="device/qcom/common" name="device/qcom/common" />
   <project path="device/qcom/msm7627a" name="platform/vendor/qcom/msm7627a" />
   <project path="device/qcom/hamachi" name="android-device-hamachi" remote="b2g" revision="master" />
-  <project path="kernel" name="kernel/msm" />
+  <project path="kernel" name="codeaurora_kernel_msm" remote="b2g" revision="ics_strawberry" />
   <project path="hardware/qcom/camera" name="platform/hardware/qcom/camera" />
   <project path="hardware/qcom/display" name="platform/hardware/qcom/display" />
   <project path="hardware/qcom/media" name="platform/hardware/qcom/media" />


### PR DESCRIPTION
Due to hamachi use ics_strawberry_rb5.1 version, the kernel and hardware/qcom/display need to use the version from caf for compatibility.
