### PR TITLE
Bug 809367: Use bionic libc from CAF remote's ICS 4.2

### DIFF
--- a/pandaboard.xml
+++ b/pandaboard.xml
@@ -9,7 +9,7 @@
            fetch="git://android.git.linaro.org/" />
   <remote name="mozilla"
 	  fetch="git://github.com/mozilla/" />
-  <remote name="mozillaorg" 
+  <remote name="mozillaorg"
       fetch="https://git.mozilla.org" />
   <default revision="refs/tags/android-4.0.4_r2.1"
            remote="linaro"
@@ -28,7 +28,7 @@
 
   <!-- Stock Android things -->
   <project path="abi/cpp" name="platform/abi/cpp" />
-  <project path="bionic" name="platform/bionic" />
+  <project path="bionic" name="platform/bionic" remote="linaro" revision="ics-plus-aosp" />
   <project path="bootable/recovery" name="platform/bootable/recovery" />
   <project path="device/common" name="device/common" />
   <project path="device/sample" name="device/sample" />


### PR DESCRIPTION
This change brings the PandaBoard's libc up to the state of the Otoro's or
Unagi's libc. The new version contains a patch for not allocating memory
when setting up a process's CPU accounting after forking.

Change-Id: Icd9ccff9fe2a9de7d9c70af7be813ff451881070
Signed-off-by: Thomas Zimmermann tdz@users.sourceforge.net
