### PR TITLE
[bug 813710] Switch master manifest branch to git.m.o for Gaia and Gecko

### DIFF
--- a/emulator.xml
+++ b/emulator.xml
@@ -9,6 +9,8 @@
           fetch="git://github.com/mozilla-b2g/" />
   <remote name="mozilla"
 	  fetch="git://github.com/mozilla/" />
+  <remote name="mozillaorg" 
+      fetch="https://git.mozilla.org" />
   <default revision="refs/tags/android-4.0.4_r2.1"
            remote="linaro"
            sync-j="4" />
@@ -18,8 +20,8 @@
     <copyfile src="core/root.mk" dest="Makefile" />
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="gaia" remote="b2g" revision="master" />
-  <project path="gecko" name="releases-mozilla-central" remote="mozilla" revision="master" />
+  <project path="gaia" name="releases/gaia.git" remote="mozillaorg" revision="master" />
+  <project path="gecko" name="releases/gecko.git" remote="mozillaorg" revision="master" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="hardware/ril" name="platform_hardware_ril" remote="b2g" revision="master"/>

--- a/galaxy-nexus.xml
+++ b/galaxy-nexus.xml
@@ -9,6 +9,8 @@
            fetch="git://android.git.linaro.org/" />
   <remote name="mozilla"
 	  fetch="git://github.com/mozilla/" />
+  <remote name="mozillaorg" 
+      fetch="https://git.mozilla.org" />
   <default revision="refs/tags/android-4.0.4_r1.2"
            remote="linaro"
            sync-j="4" />
@@ -18,8 +20,8 @@
     <copyfile src="core/root.mk" dest="Makefile" />
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="gaia" remote="b2g" revision="master" />
-  <project path="gecko" name="releases-mozilla-central" remote="mozilla" revision="master" />
+  <project path="gaia" name="releases/gaia.git" remote="mozillaorg" revision="master" />
+  <project path="gecko" name="releases/gecko.git" remote="mozillaorg" revision="master" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />

--- a/galaxy-s2.xml
+++ b/galaxy-s2.xml
@@ -9,6 +9,8 @@
            fetch="git://android.git.linaro.org/" />
   <remote name="mozilla"
 	  fetch="git://github.com/mozilla/" />
+  <remote name="mozillaorg"
+      fetch="https://git.mozilla.org" />
   <default revision="refs/tags/android-4.0.4_r1.2"
            remote="linaro"
            sync-j="4" />
@@ -18,8 +20,8 @@
     <copyfile src="core/root.mk" dest="Makefile" />
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="gaia" remote="b2g" revision="master" />
-  <project path="gecko" name="releases-mozilla-central" remote="mozilla" revision="master" />
+  <project path="gaia" name="releases/gaia.git" remote="mozillaorg" revision="master" />
+  <project path="gecko" name="releases/gecko.git" remote="mozillaorg" revision="master" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />

--- a/hamachi.xml
+++ b/hamachi.xml
@@ -11,6 +11,8 @@
           fetch="git://codeaurora.org/" />
   <remote  name="linaro"
            fetch="git://android.git.linaro.org/" />
+  <remote name="mozillaorg"
+           fetch="https://git.mozilla.org" />
   <default revision="ics_strawberry_rb5.1"
            remote="caf"
            sync-j="4" />
@@ -20,8 +22,8 @@
     <copyfile src="core/root.mk" dest="Makefile" />
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="gaia" remote="b2g" revision="master" />
-  <project path="gecko" name="releases-mozilla-central" remote="mozilla" revision="master" />
+  <project path="gaia" name="releases/gaia.git" remote="mozillaorg" revision="master" />
+  <project path="gecko" name="releases/gecko.git" remote="mozillaorg" revision="master" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="librecovery" name="librecovery" remote="b2g" revision="master" />

--- a/nexus-s-4g.xml
+++ b/nexus-s-4g.xml
@@ -9,6 +9,8 @@
            fetch="git://android.git.linaro.org/" />
   <remote name="mozilla"
 	  fetch="git://github.com/mozilla/" />
+  <remote name="mozillaorg"
+      fetch="https://git.mozilla.org" />
   <default revision="refs/tags/android-4.0.4_r1.2"
            remote="linaro"
            sync-j="4" />
@@ -18,8 +20,8 @@
     <copyfile src="core/root.mk" dest="Makefile" />
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="gaia" remote="b2g" revision="master" />
-  <project path="gecko" name="releases-mozilla-central" remote="mozilla" revision="master" />
+  <project path="gaia" name="releases/gaia.git" remote="mozillaorg" revision="master" />
+  <project path="gecko" name="releases/gecko.git" remote="mozillaorg" revision="master" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />

--- a/nexus-s.xml
+++ b/nexus-s.xml
@@ -9,6 +9,8 @@
            fetch="git://android.git.linaro.org/" />
   <remote name="mozilla"
 	  fetch="git://github.com/mozilla/" />
+  <remote name="mozillaorg" 
+      fetch="https://git.mozilla.org" />
   <default revision="refs/tags/android-4.0.4_r1.2"
            remote="linaro"
            sync-j="4" />
@@ -18,8 +20,8 @@
     <copyfile src="core/root.mk" dest="Makefile" />
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="gaia" remote="b2g" revision="master" />
-  <project path="gecko" name="releases-mozilla-central" remote="mozilla" revision="master" />
+  <project path="gaia" name="releases/gaia.git" remote="mozillaorg" revision="master" />
+  <project path="gecko" name="releases/gecko.git" remote="mozillaorg" revision="master" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />

--- a/optimus-l5.xml
+++ b/optimus-l5.xml
@@ -11,6 +11,8 @@
           fetch="git://codeaurora.org/" />
   <remote  name="linaro"
            fetch="git://android.git.linaro.org/" />
+  <remote name="mozillaorg"
+           fetch="https://git.mozilla.org" />
   <default revision="ics_chocolate"
            remote="caf"
            sync-j="4" />
@@ -20,8 +22,8 @@
     <copyfile src="core/root.mk" dest="Makefile" />
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="gaia" remote="b2g" revision="master" />
-  <project path="gecko" name="releases-mozilla-central" remote="mozilla" revision="master" />
+  <project path="gaia" name="releases/gaia.git" remote="mozillaorg" revision="master" />
+  <project path="gecko" name="releases/gecko.git" remote="mozillaorg" revision="master" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />

--- a/otoro.xml
+++ b/otoro.xml
@@ -11,6 +11,8 @@
           fetch="git://codeaurora.org/" />
   <remote  name="linaro"
            fetch="git://android.git.linaro.org/" />
+  <remote name="mozillaorg"
+           fetch="https://git.mozilla.org" />
   <default revision="ics_chocolate_rb4.2"
            remote="caf"
            sync-j="4" />
@@ -20,8 +22,8 @@
     <copyfile src="core/root.mk" dest="Makefile" />
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="gaia" remote="b2g" revision="master" />
-  <project path="gecko" name="releases-mozilla-central" remote="mozilla" revision="master" />
+  <project path="gaia" name="releases/gaia.git" remote="mozillaorg" revision="master" />
+  <project path="gecko" name="releases/gecko.git" remote="mozillaorg" revision="master" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="librecovery" name="librecovery" remote="b2g" revision="master" />

--- a/pandaboard.xml
+++ b/pandaboard.xml
@@ -9,6 +9,8 @@
            fetch="git://android.git.linaro.org/" />
   <remote name="mozilla"
 	  fetch="git://github.com/mozilla/" />
+  <remote name="mozillaorg" 
+      fetch="https://git.mozilla.org" />
   <default revision="refs/tags/android-4.0.4_r2.1"
            remote="linaro"
            sync-j="4" />
@@ -18,8 +20,8 @@
     <copyfile src="core/root.mk" dest="Makefile" />
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="gaia" remote="b2g" revision="master" />
-  <project path="gecko" name="releases-mozilla-central" remote="mozilla" revision="master" />
+  <project path="gaia" name="releases/gaia.git" remote="mozillaorg" revision="master" />
+  <project path="gecko" name="releases/gecko.git" remote="mozillaorg" revision="master" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />


### PR DESCRIPTION
This sets up the git.mozilla.org remote in the manifest and uses it for Gecko and Gaia.  We should communicate this before landing to give a heads up that this change is happening to the default development source tree.

cc @cgjones @michaelwu
