### PR TITLE
Bug 816179: Support Oprofile on PandaBoard

### DIFF
--- a/pandaboard.xml
+++ b/pandaboard.xml
@@ -103,6 +103,7 @@
   <project path="hardware/ti/wlan" name="platform/hardware/ti/wlan" revision="60dfeb6e4448bfed707946ebca6612980f525e69" />
   <project path="hardware/ti/wpan" name="platform/hardware/ti/wpan" revision="3ece7d9e08052989401e008bc397dbcd2557cfd0" />
   <project path="external/negatus" name="Negatus" remote="mozilla" revision="master" />
+  <project path="external/oprofile" name="platform/external/oprofile" revision="ics-plus-aosp" />
   <project path="external/orangutan" name="orangutan" remote="b2g" revision="master" />
 
 </manifest>


### PR DESCRIPTION
The commit adds oprofile to the external programs for the PandaBoard.

Change-Id: I8f47c67e46c8c28f6deeec8a5fa2b829d0fb5af5
Signed-off-by: Thomas Zimmermann tdz@users.sourceforge.net
