### PR TITLE
[bug 818368] use .git suffix for git.mozilla.org hosted repositories

### DIFF
--- a/emulator.xml
+++ b/emulator.xml
@@ -20,8 +20,8 @@
     <copyfile src="core/root.mk" dest="Makefile" />
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="releases/gaia" remote="mozillaorg" revision="nightly" />
-  <project path="gecko" name="releases/gecko" remote="mozillaorg" revision="gecko-18" />
+  <project path="gaia" name="releases/gaia.git" remote="mozillaorg" revision="nightly" />
+  <project path="gecko" name="releases/gecko.git" remote="mozillaorg" revision="gecko-18" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="hardware/ril" name="platform_hardware_ril" remote="b2g" revision="master"/>

--- a/galaxy-nexus.xml
+++ b/galaxy-nexus.xml
@@ -20,8 +20,8 @@
     <copyfile src="core/root.mk" dest="Makefile" />
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="releases/gaia" remote="mozillaorg" revision="nightly" />
-  <project path="gecko" name="releases/gecko" remote="mozillaorg" revision="gecko-18" />
+  <project path="gaia" name="releases/gaia.git" remote="mozillaorg" revision="nightly" />
+  <project path="gecko" name="releases/gecko.git" remote="mozillaorg" revision="gecko-18" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />

--- a/galaxy-s2.xml
+++ b/galaxy-s2.xml
@@ -20,8 +20,8 @@
     <copyfile src="core/root.mk" dest="Makefile" />
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="releases/gaia" remote="mozillaorg" revision="nightly" />
-  <project path="gecko" name="releases/gecko" remote="mozillaorg" revision="gecko-18" />
+  <project path="gaia" name="releases/gaia.git" remote="mozillaorg" revision="nightly" />
+  <project path="gecko" name="releases/gecko.git" remote="mozillaorg" revision="gecko-18" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />

--- a/nexus-s-4g.xml
+++ b/nexus-s-4g.xml
@@ -20,8 +20,8 @@
     <copyfile src="core/root.mk" dest="Makefile" />
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="releases/gaia" remote="mozillaorg" revision="nightly" />
-  <project path="gecko" name="releases/gecko" remote="mozillaorg" revision="gecko-18" />
+  <project path="gaia" name="releases/gaia.git" remote="mozillaorg" revision="nightly" />
+  <project path="gecko" name="releases/gecko.git" remote="mozillaorg" revision="gecko-18" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />

--- a/nexus-s.xml
+++ b/nexus-s.xml
@@ -20,8 +20,8 @@
     <copyfile src="core/root.mk" dest="Makefile" />
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="releases/gaia" remote="mozillaorg" revision="nightly" />
-  <project path="gecko" name="releases/gecko" remote="mozillaorg" revision="gecko-18" />
+  <project path="gaia" name="releases/gaia.git" remote="mozillaorg" revision="nightly" />
+  <project path="gecko" name="releases/gecko.git" remote="mozillaorg" revision="gecko-18" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />

--- a/optimus-l5.xml
+++ b/optimus-l5.xml
@@ -22,8 +22,8 @@
     <copyfile src="core/root.mk" dest="Makefile" />
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="releases/gaia" remote="mozillaorg" revision="nightly" />
-  <project path="gecko" name="releases/gecko" remote="mozillaorg" revision="gecko-18" />
+  <project path="gaia" name="releases/gaia.git" remote="mozillaorg" revision="nightly" />
+  <project path="gecko" name="releases/gecko.git" remote="mozillaorg" revision="gecko-18" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />

--- a/otoro.xml
+++ b/otoro.xml
@@ -22,8 +22,8 @@
     <copyfile src="core/root.mk" dest="Makefile" />
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="releases/gaia" remote="mozillaorg" revision="nightly" />
-  <project path="gecko" name="releases/gecko" remote="mozillaorg" revision="gecko-18" />
+  <project path="gaia" name="releases/gaia.git" remote="mozillaorg" revision="nightly" />
+  <project path="gecko" name="releases/gecko.git" remote="mozillaorg" revision="gecko-18" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="librecovery" name="librecovery" remote="b2g" revision="master" />

--- a/pandaboard.xml
+++ b/pandaboard.xml
@@ -20,8 +20,8 @@
     <copyfile src="core/root.mk" dest="Makefile" />
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="releases/gaia" remote="mozillaorg" revision="nightly" />
-  <project path="gecko" name="releases/gecko" remote="mozillaorg" revision="gecko-18" />
+  <project path="gaia" name="releases/gaia.git" remote="mozillaorg" revision="nightly" />
+  <project path="gecko" name="releases/gecko.git" remote="mozillaorg" revision="gecko-18" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />


### PR DESCRIPTION
Nightly version of https://github.com/mozilla-b2g/b2g-manifest/pull/31
