### PR TITLE
Bug 817730: Revert "Bug 809367: Switch bionic to linaro/ics-plus-aosp on...

### DIFF
--- a/pandaboard.xml
+++ b/pandaboard.xml
@@ -9,7 +9,7 @@
            fetch="git://android.git.linaro.org/" />
   <remote name="mozilla"
 	  fetch="git://github.com/mozilla/" />
-  <remote name="mozillaorg"
+  <remote name="mozillaorg" 
       fetch="https://git.mozilla.org" />
   <default revision="refs/tags/android-4.0.4_r2.1"
            remote="linaro"
@@ -28,7 +28,7 @@
 
   <!-- Stock Android things -->
   <project path="abi/cpp" name="platform/abi/cpp" />
-  <project path="bionic" name="platform/bionic" revision="ics-plus-aosp" />
+  <project path="bionic" name="platform/bionic" />
   <project path="bootable/recovery" name="platform/bootable/recovery" />
   <project path="device/common" name="device/common" />
   <project path="device/sample" name="device/sample" />


### PR DESCRIPTION
... PandaBoard"

This reverts commit 6a099783843922d26093eafd94c56cb25290fbc7.

We had reports about stability problems and hang ups since this
update was deployed.
