### PR TITLE
Move the rest of the devices over to git.mozilla.org

### DIFF
--- a/galaxy-nexus.xml
+++ b/galaxy-nexus.xml
@@ -4,7 +4,7 @@
   <remote  name="aosp"
            fetch="https://android.googlesource.com/" />
   <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
+          fetch="https://git.mozilla.org/b2g/" />
   <remote  name="linaro"
            fetch="git://android.git.linaro.org/" />
   <remote name="mozilla"

--- a/galaxy-s2.xml
+++ b/galaxy-s2.xml
@@ -4,7 +4,7 @@
   <remote  name="aosp"
            fetch="https://android.googlesource.com/" />
   <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
+          fetch="https://git.mozilla.org/b2g/" />
   <remote  name="linaro"
            fetch="git://android.git.linaro.org/" />
   <remote name="mozilla"

--- a/nexus-s-4g.xml
+++ b/nexus-s-4g.xml
@@ -4,7 +4,7 @@
   <remote  name="aosp"
            fetch="https://android.googlesource.com/" />
   <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
+          fetch="https://git.mozilla.org/b2g/" />
   <remote  name="linaro"
            fetch="git://android.git.linaro.org/" />
   <remote name="mozilla"

--- a/nexus-s.xml
+++ b/nexus-s.xml
@@ -4,7 +4,7 @@
   <remote  name="aosp"
            fetch="https://android.googlesource.com/" />
   <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
+          fetch="https://git.mozilla.org/b2g/" />
   <remote  name="linaro"
            fetch="git://android.git.linaro.org/" />
   <remote name="mozilla"

--- a/optimus-l5.xml
+++ b/optimus-l5.xml
@@ -4,7 +4,7 @@
   <remote  name="aosp"
            fetch="https://android.googlesource.com/" />
   <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
+          fetch="https://git.mozilla.org/b2g/" />
   <remote name="mozilla"
 	  fetch="git://github.com/mozilla/" />
   <remote name="caf"

--- a/pandaboard.xml
+++ b/pandaboard.xml
@@ -4,7 +4,7 @@
   <remote  name="aosp"
            fetch="https://android.googlesource.com/" />
   <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
+          fetch="https://git.mozilla.org/b2g/" />
   <remote  name="linaro"
            fetch="git://android.git.linaro.org/" />
   <remote name="mozilla"


### PR DESCRIPTION
We should be using git.mozilla.org on all devices
