### PR TITLE
[Bug 836105] freezing revsion attributes for the v1.0.0 branch

### DIFF
--- a/emulator.xml
+++ b/emulator.xml
@@ -1,109 +1,102 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote  name="linaro"
-           fetch="git://android.git.linaro.org/" />
-  <remote name="b2g"
-           fetch="https://git.mozilla.org/b2g" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="mozillaorg" 
-      fetch="https://git.mozilla.org/releases" />
-  <default revision="refs/tags/android-4.0.4_r2.1"
-           remote="linaro"
-           sync-j="4" />
+  <remote name="aosp" fetch="https://android.googlesource.com/"/>
+  <remote name="linaro" fetch="git://android.git.linaro.org/"/>
+  <remote name="b2g" fetch="https://git.mozilla.org/b2g"/>
+  <remote name="mozilla" fetch="git://github.com/mozilla/"/>
+  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases"/>
+  <default revision="refs/tags/android-4.0.4_r2.1" remote="linaro" sync-j="4"/>
 
   <!-- Gonk specific things and forks -->
-  <project path="build" name="platform_build" remote="b2g" revision="master">
-    <copyfile src="core/root.mk" dest="Makefile" />
+  <project path="build" name="platform_build" remote="b2g" revision="43434d6cdbf702e6197e0791f19406860284edf6" upstream="v1.0.0">
+    <copyfile src="core/root.mk" dest="Makefile"/>
   </project>
-  <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="gaia.git" remote="mozillaorg" revision="v1.0.0" />
-  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="v1.0.0" />
-  <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
-  <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
-  <project path="hardware/ril" name="platform_hardware_ril" remote="b2g" revision="master"/>
-  <project path="external/qemu" name="platform_external_qemu" remote="b2g" revision="master"/>
-  <project path="external/moztt" name="moztt" remote="b2g" revision="master" />
+  <project path="dalvik" name="fake-dalvik" remote="b2g" revision="ca1f327d5acc198bb4be62fa51db2c039032c9ce" upstream="v1.0.0"/>
+  <project path="gaia" name="gaia.git" remote="mozillaorg" revision="v1.0.0"/>
+  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="v1.0.0"/>
+  <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="f46dac73e6256c25763764d5fa26ac1bdf1417ba" upstream="v1.0.0"/>
+  <project path="rilproxy" name="rilproxy" remote="b2g" revision="f634b3d50effdd42828cc757c01fdbf74e562a36" upstream="v1.0.0"/>
+  <project path="hardware/ril" name="platform_hardware_ril" remote="b2g" revision="2a617dd170a3828739439ae08110e0266a3d8766" upstream="v1.0.0"/>
+  <project path="external/qemu" name="platform_external_qemu" remote="b2g" revision="72c8f4310525d6f01b5c9b36dd52b41f0d76382f" upstream="v1.0.0"/>
+  <project path="external/moztt" name="moztt" remote="b2g" revision="6ee1f8987ef36d688f97064c003ad57849dfadf2" upstream="v1.0.0"/>
 
   <!-- Stock Android things -->
-  <project path="abi/cpp" name="platform/abi/cpp" />
-  <project path="bionic" name="platform/bionic" />
-  <project path="bootable/recovery" name="platform/bootable/recovery" />
-  <project path="device/common" name="device/common" />
-  <project path="device/sample" name="device/sample" />
-  <project path="external/apache-http" name="platform/external/apache-http" />
-  <project path="external/bluetooth/bluez" name="platform/external/bluetooth/bluez" />
-  <project path="external/bluetooth/glib" name="platform/external/bluetooth/glib" />
-  <project path="external/bluetooth/hcidump" name="platform/external/bluetooth/hcidump" />
-  <project path="external/bsdiff" name="platform/external/bsdiff" />
-  <project path="external/bzip2" name="platform/external/bzip2" />
-  <project path="external/dbus" name="platform/external/dbus" />
-  <project path="external/dhcpcd" name="platform/external/dhcpcd" />
-  <project path="external/dnsmasq" name="platform/external/dnsmasq" />
-  <project path="external/expat" name="platform/external/expat" />
-  <project path="external/fdlibm" name="platform/external/fdlibm" />
-  <project path="external/flac" name="platform/external/flac" />
-  <project path="external/freetype" name="platform/external/freetype" revision="15321e16a085b9b5c85cf029aee86bf57b2e65c1" />
-  <project path="external/giflib" name="platform/external/giflib" />
-  <project path="external/gtest" name="platform/external/gtest" revision="master" />
-  <project path="external/harfbuzz" name="platform/external/harfbuzz" />
-  <project path="external/icu4c" name="platform/external/icu4c" />
-  <project path="external/iptables" name="platform/external/iptables" />
-  <project path="external/jhead" name="platform/external/jhead" />
-  <project path="external/jpeg" name="platform/external/jpeg" />
-  <project path="external/libgsm" name="platform/external/libgsm" />
-  <project path="external/liblzf" name="platform/external/liblzf" />
-  <project path="external/libnfc-nxp" name="platform/external/libnfc-nxp" />
-  <project path="external/libnl-headers" name="platform/external/libnl-headers" />
-  <project path="external/libphonenumber" name="platform/external/libphonenumber" />
-  <project path="external/libpng" name="platform/external/libpng" />
-  <project path="external/libvpx" name="platform/external/libvpx" />
-  <project path="external/mksh" name="platform/external/mksh" />
-  <project path="external/opensans" name="platform_external_opensans" remote="b2g" revision="master" />
-  <project path="external/openssl" name="platform/external/openssl" />
-  <project path="external/protobuf" name="platform/external/protobuf" />
-  <project path="external/safe-iop" name="platform/external/safe-iop" />
-  <project path="external/screencap-gonk" name="screencap-gonk" remote="b2g" revision="master" />
-  <project path="external/skia" name="platform/external/skia" revision="8c1c7cfacd82a174c65fcbf839d7037e3692aee8" />
-  <project path="external/sonivox" name="platform/external/sonivox" />
-  <project path="external/speex" name="platform/external/speex" />
-  <project path="external/sqlite" name="platform/external/sqlite" />
-  <project path="external/stlport" name="platform/external/stlport" />
-  <project path="external/strace" name="platform/external/strace" />
-  <project path="external/tagsoup" name="platform/external/tagsoup" />
-  <project path="external/tinyalsa" name="platform/external/tinyalsa" />
-  <project path="external/tremolo" name="platform/external/tremolo" />
-  <project path="external/webp" name="platform/external/webp" />
-  <project path="external/webrtc" name="platform/external/webrtc" />
-  <project path="external/wpa_supplicant" name="platform/external/wpa_supplicant" />
-  <project path="external/wpa_supplicant_8" name="platform/external/wpa_supplicant_8" />
-  <project path="external/zlib" name="platform/external/zlib" />
-  <project path="external/yaffs2" name="platform/external/yaffs2" />
-  <project path="frameworks/base" name="platform/frameworks/base" revision="612ca9c6a55bd932c45f5b85ae932a1b712dd914" />
-  <project path="frameworks/opt/emoji" name="platform/frameworks/opt/emoji" />
-  <project path="frameworks/support" name="platform/frameworks/support" />
-  <project path="hardware/libhardware" name="platform/hardware/libhardware" />
-  <project path="hardware/libhardware_legacy" name="platform/hardware/libhardware_legacy" revision="af9565aa8be0136463ec549d9d3abdd906d2c390" />
-  <project path="libcore" name="platform/libcore" />
-  <project path="ndk" name="platform/ndk" />
-  <project path="prebuilt" name="platform/prebuilt" revision="master" />
-  <project path="system/bluetooth" name="platform/system/bluetooth" />
-  <project path="system/core" name="platform/system/core" revision="91e5551f88aea5aa64e1b4f8b4b52d7be2b28b64" />
-  <project path="system/extras" name="platform/system/extras" />
-  <project path="system/media" name="platform/system/media" />
-  <project path="system/netd" name="platform/system/netd" />
-  <project path="system/vold" name="platform/system/vold" />
+  <project path="abi/cpp" name="platform/abi/cpp" revision="6426040f1be4a844082c9769171ce7f5341a5528"/>
+  <project path="bionic" name="platform/bionic" revision="3d11bf0f3f3cf848f6f1e8449bf8736d8d1c78a3"/>
+  <project path="bootable/recovery" name="platform/bootable/recovery" revision="fadc5ac81d6400ebdd041f7d4ea64021596d6b7d"/>
+  <project path="device/common" name="device/common" revision="7d4526582f88808a3194e1a3b304abb369d2745c"/>
+  <project path="device/sample" name="device/sample" revision="ef228b8b377a9663e94be4b1aeb6c2bf7a07d098"/>
+  <project path="external/apache-http" name="platform/external/apache-http" revision="6c9d8c58d3ed710f87c26820d903bb8aad81754f"/>
+  <project path="external/bluetooth/bluez" name="platform/external/bluetooth/bluez" revision="966afbd88f0bfc325bf80274ad2723c238883fa1"/>
+  <project path="external/bluetooth/glib" name="platform/external/bluetooth/glib" revision="1143b9918eab068401b604eb11c3f651f4e38b25"/>
+  <project path="external/bluetooth/hcidump" name="platform/external/bluetooth/hcidump" revision="7322661808c2006b7848e79e6bb72b37fbcf6710"/>
+  <project path="external/bsdiff" name="platform/external/bsdiff" revision="81872540236d9bb15cccf963d05b9de48baa5375"/>
+  <project path="external/bzip2" name="platform/external/bzip2" revision="048dacdca43eed1534689ececcf2781c63e1e4ba"/>
+  <project path="external/dbus" name="platform/external/dbus" revision="537eaff5de9aace3348436166d4cde7adc1e488e"/>
+  <project path="external/dhcpcd" name="platform/external/dhcpcd" revision="ddaa48f57b54b2862b3e6dcf18a44c9647f3baaa"/>
+  <project path="external/dnsmasq" name="platform/external/dnsmasq" revision="f621afad94df46204c25fc2593a19d704d2637f5"/>
+  <project path="external/expat" name="platform/external/expat" revision="6df134250feab71edb5915ecaa6268210bca76c5"/>
+  <project path="external/fdlibm" name="platform/external/fdlibm" revision="988ffeb12a6e044ae3504838ef1fee3fe0716934"/>
+  <project path="external/flac" name="platform/external/flac" revision="5893fbe890f5dab8e4146d2baa4bd2691c0739e0"/>
+  <project path="external/freetype" name="platform/external/freetype" revision="15321e16a085b9b5c85cf029aee86bf57b2e65c1"/>
+  <project path="external/giflib" name="platform/external/giflib" revision="b2597268aef084202a8c349d1cc072c03c6e22eb"/>
+  <project path="external/gtest" name="platform/external/gtest" revision="344e5f3db17615cc853073a02968a603efd39109"/>
+  <project path="external/harfbuzz" name="platform/external/harfbuzz" revision="bae491c03a00757d83ede8d855b7d85d246bde3d"/>
+  <project path="external/icu4c" name="platform/external/icu4c" revision="0fa67b93b831c6636ca18b152a1b1b14cc99b034"/>
+  <project path="external/iptables" name="platform/external/iptables" revision="3b2deb17f065c5664bb25e1a28489e5792eb63ff"/>
+  <project path="external/jhead" name="platform/external/jhead" revision="754078052c687f6721536009c816644c73e4f145"/>
+  <project path="external/jpeg" name="platform/external/jpeg" revision="d4fad7f50f79626455d88523207e05b868819cd8"/>
+  <project path="external/libgsm" name="platform/external/libgsm" revision="5e4516958690b9a1b2c98f88eeecba3edd2dbda4"/>
+  <project path="external/liblzf" name="platform/external/liblzf" revision="6946aa575b0949d045722794850896099d937cbb"/>
+  <project path="external/libnfc-nxp" name="platform/external/libnfc-nxp" revision="533c14450e6239cce8acb74f4e4dea2c89f8f219"/>
+  <project path="external/libnl-headers" name="platform/external/libnl-headers" revision="6ccf7349d61f73ac26a0675d735d903ab919c658"/>
+  <project path="external/libphonenumber" name="platform/external/libphonenumber" revision="d470984844c388d6766c3de6ac64e93e00480fc9"/>
+  <project path="external/libpng" name="platform/external/libpng" revision="84d92c718ab9f48faec0f640747c4b6f7a995607"/>
+  <project path="external/libvpx" name="platform/external/libvpx" revision="3a40da0d96da5c520e7707aa14f48a80956e20d7"/>
+  <project path="external/mksh" name="platform/external/mksh" revision="5155f1c7438ef540d7b25eb70aa1639579795b07"/>
+  <project path="external/opensans" name="platform_external_opensans" remote="b2g" revision="b5b4c226ca1d71e936153cf679dda6d3d60e2354" upstream="v1.0.0"/>
+  <project path="external/openssl" name="platform/external/openssl" revision="ce96fb211b9a44bbd7fb5ef7ed0e6c1244045c2e"/>
+  <project path="external/protobuf" name="platform/external/protobuf" revision="e217977611c52bccde7f7c78e1d3c790c6357431"/>
+  <project path="external/safe-iop" name="platform/external/safe-iop" revision="07073634e2e3aa4f518e36ed5dec3aabc549d5fb"/>
+  <project path="external/screencap-gonk" name="screencap-gonk" remote="b2g" revision="e6403c71e9eca8cb943739d5a0a192deac60fc51" upstream="v1.0.0"/>
+  <project path="external/skia" name="platform/external/skia" revision="8c1c7cfacd82a174c65fcbf839d7037e3692aee8"/>
+  <project path="external/sonivox" name="platform/external/sonivox" revision="5f9600971859fe072f31b38a51c38157f5f9b381"/>
+  <project path="external/speex" name="platform/external/speex" revision="ebe6230a7f7c69f5a4389f2b09b7b19ef9e94f32"/>
+  <project path="external/sqlite" name="platform/external/sqlite" revision="c999ff8c12a4cf81cb9ad628f47b2720effba5e5"/>
+  <project path="external/stlport" name="platform/external/stlport" revision="a6734e0645fce81c9610de0488b729207bfa576e"/>
+  <project path="external/strace" name="platform/external/strace" revision="c9fd2e5ef7d002e12e7cf2512506c84a9414b0fd"/>
+  <project path="external/tagsoup" name="platform/external/tagsoup" revision="68c2ec9e0acdb3214b7fb91dbab8c9fab8736817"/>
+  <project path="external/tinyalsa" name="platform/external/tinyalsa" revision="495239e683a728957c890c124b239f9b7b8ef5a8"/>
+  <project path="external/tremolo" name="platform/external/tremolo" revision="25bd78d2392dbdc879ae53382cde9d019f79cf6f"/>
+  <project path="external/webp" name="platform/external/webp" revision="88fe2b83c4b9232cd08729556fd0485d6a6a92cd"/>
+  <project path="external/webrtc" name="platform/external/webrtc" revision="4b6dc1ec58105d17dc8c2f550124cc0621dc93b7"/>
+  <project path="external/wpa_supplicant" name="platform/external/wpa_supplicant" revision="a01d37870bbf9892d43e792e5de0683ca41c5497"/>
+  <project path="external/wpa_supplicant_8" name="platform/external/wpa_supplicant_8" revision="648b7492d15bb4efaeebdfdd8bd261563a5f6227"/>
+  <project path="external/zlib" name="platform/external/zlib" revision="69e5801bd16a495e1c1666669fe827b1ddb8d56b"/>
+  <project path="external/yaffs2" name="platform/external/yaffs2" revision="6232e2d5ab34a40d710e4b05ab0ec6e3727804e7"/>
+  <project path="frameworks/base" name="platform/frameworks/base" revision="612ca9c6a55bd932c45f5b85ae932a1b712dd914"/>
+  <project path="frameworks/opt/emoji" name="platform/frameworks/opt/emoji" revision="a95d8db002770469d72dfaf59ff37ac96db29a87"/>
+  <project path="frameworks/support" name="platform/frameworks/support" revision="bfc8e01b7b0d5ea70ce89d0409b72b7f7d540f43"/>
+  <project path="hardware/libhardware" name="platform/hardware/libhardware" revision="a9b677fce432b29ab8f61e13796f34880dc0fe0f"/>
+  <project path="hardware/libhardware_legacy" name="platform/hardware/libhardware_legacy" revision="af9565aa8be0136463ec549d9d3abdd906d2c390"/>
+  <project path="libcore" name="platform/libcore" revision="fc294a48d80d9e2b2ac126edf93ad316f5f6cf72"/>
+  <project path="ndk" name="platform/ndk" revision="2d77f5a05f60029c981f299b222cfe28db18ccf7"/>
+  <project path="prebuilt" name="platform/prebuilt" revision="a4062cc40fcaa0776dc880ce591b4c515d36f420"/>
+  <project path="system/bluetooth" name="platform/system/bluetooth" revision="2588cd802f322650ed737dfb7a10e9ad94064e99"/>
+  <project path="system/core" name="platform/system/core" revision="91e5551f88aea5aa64e1b4f8b4b52d7be2b28b64"/>
+  <project path="system/extras" name="platform/system/extras" revision="fa351ab265957fa8815df3c4ca1f3c105f253e8b"/>
+  <project path="system/media" name="platform/system/media" revision="a8eea50f80327f15cb04bbdfee2d1cfcc4c3ce4a"/>
+  <project path="system/netd" name="platform/system/netd" revision="3c903b555975fa59d6688a0a6417ac7512c202e7"/>
+  <project path="system/vold" name="platform/system/vold" revision="3ad9072a5d6f6bda32123b367545649364e3c11d"/>
 
   <!-- Emulator specific things -->
-  <project path="development" name="platform/development" revision="435a7da6d02083ba6583e1654db351991cf79578" />
-  <project path="device/generic/goldfish" name="device/generic/goldfish" />
-  <project path="prebuilts/gcc/linux-x86/host/i686-linux-glibc2.7-4.6" name="platform/prebuilts/gcc/linux-x86/host/i686-linux-glibc2.7-4.6" revision="master" />
-  <project path="prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.7-4.6" name="platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.7-4.6" revision="master" />
-  <project path="prebuilts/tools" name="platform/prebuilts/tools" revision="master" />
-  <project path="prebuilts/qemu-kernel" name="platform/prebuilts/qemu-kernel" revision="master" />
-  <project path="sdk" name="platform/sdk" revision="0d8f973905a4925e00eb9e32887c192b2148b29f" />
+  <project path="development" name="platform/development" revision="435a7da6d02083ba6583e1654db351991cf79578"/>
+  <project path="device/generic/goldfish" name="device/generic/goldfish" revision="5feb8ecfd93c4e3c9eec89ab20dd143d05f7e91c"/>
+  <project path="prebuilts/gcc/linux-x86/host/i686-linux-glibc2.7-4.6" name="platform/prebuilts/gcc/linux-x86/host/i686-linux-glibc2.7-4.6" revision="764d33d301b1363970a2aefd4dbb6766baeb62f7"/>
+  <project path="prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.7-4.6" name="platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.7-4.6" revision="ebdad82e61c16772f6cd47e9f11936bf6ebe9aa0"/>
+  <project path="prebuilts/tools" name="platform/prebuilts/tools" revision="7c7ca5eac957b10a19475c1f82b5189e7438d40d"/>
+  <project path="prebuilts/qemu-kernel" name="platform/prebuilts/qemu-kernel" revision="44b5e548c030d80548d201731e57d71892c51934"/>
+  <project path="sdk" name="platform/sdk" revision="0d8f973905a4925e00eb9e32887c192b2148b29f"/>
 
 </manifest>

--- a/galaxy-nexus.xml
+++ b/galaxy-nexus.xml
@@ -1,108 +1,101 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote  name="linaro"
-           fetch="git://android.git.linaro.org/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="mozillaorg" 
-      fetch="https://git.mozilla.org/releases" />
-  <default revision="refs/tags/android-4.0.4_r1.2"
-           remote="linaro"
-           sync-j="4" />
+  <remote name="aosp" fetch="https://android.googlesource.com/"/>
+  <remote name="b2g" fetch="git://github.com/mozilla-b2g/"/>
+  <remote name="linaro" fetch="git://android.git.linaro.org/"/>
+  <remote name="mozilla" fetch="git://github.com/mozilla/"/>
+  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases"/>
+  <default revision="refs/tags/android-4.0.4_r1.2" remote="linaro" sync-j="4"/>
 
   <!-- Gonk specific things and forks -->
-  <project path="build" name="platform_build" remote="b2g" revision="master">
-    <copyfile src="core/root.mk" dest="Makefile" />
+  <project path="build" name="platform_build" remote="b2g" revision="43434d6cdbf702e6197e0791f19406860284edf6" upstream="v1.0.0">
+    <copyfile src="core/root.mk" dest="Makefile"/>
   </project>
-  <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="gaia.git" remote="mozillaorg" revision="v1.0.0" />
-  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="v1.0.0" />
-  <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
-  <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
-  <project path="external/moztt" name="moztt" remote="b2g" revision="master" />
+  <project path="dalvik" name="fake-dalvik" remote="b2g" revision="ca1f327d5acc198bb4be62fa51db2c039032c9ce" upstream="v1.0.0"/>
+  <project path="gaia" name="gaia.git" remote="mozillaorg" revision="v1.0.0"/>
+  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="v1.0.0"/>
+  <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="f46dac73e6256c25763764d5fa26ac1bdf1417ba" upstream="v1.0.0"/>
+  <project path="rilproxy" name="rilproxy" remote="b2g" revision="f634b3d50effdd42828cc757c01fdbf74e562a36" upstream="v1.0.0"/>
+  <project path="external/moztt" name="moztt" remote="b2g" revision="6ee1f8987ef36d688f97064c003ad57849dfadf2" upstream="v1.0.0"/>
 
   <!-- Stock Android things -->
-  <project path="abi/cpp" name="platform/abi/cpp" />
-  <project path="bionic" name="platform/bionic" />
-  <project path="bootable/recovery" name="platform/bootable/recovery" />
-  <project path="device/common" name="device/common" />
-  <project path="device/sample" name="device/sample" />
-  <project path="external/apache-http" name="platform/external/apache-http" />
-  <project path="external/bluetooth/bluez" name="platform/external/bluetooth/bluez" />
-  <project path="external/bluetooth/glib" name="platform/external/bluetooth/glib" />
-  <project path="external/bluetooth/hcidump" name="platform/external/bluetooth/hcidump" />
-  <project path="external/bsdiff" name="platform/external/bsdiff" />
-  <project path="external/busybox" name="platform/external/busybox" remote="linaro" revision="linaro-1.20" />
-  <project path="external/bzip2" name="platform/external/bzip2" />
-  <project path="external/dbus" name="platform/external/dbus" />
-  <project path="external/dhcpcd" name="platform/external/dhcpcd" />
-  <project path="external/dnsmasq" name="platform/external/dnsmasq" />
-  <project path="external/expat" name="platform/external/expat" />
-  <project path="external/fdlibm" name="platform/external/fdlibm" />
-  <project path="external/flac" name="platform/external/flac" />
-  <project path="external/freetype" name="platform/external/freetype" />
-  <project path="external/giflib" name="platform/external/giflib" />
-  <project path="external/gtest" name="platform/external/gtest" remote="linaro" revision="master" />
-  <project path="external/harfbuzz" name="platform/external/harfbuzz" />
-  <project path="external/icu4c" name="platform/external/icu4c" />
-  <project path="external/iptables" name="platform/external/iptables" />
-  <project path="external/jhead" name="platform/external/jhead" />
-  <project path="external/jpeg" name="platform/external/jpeg" />
-  <project path="external/libgsm" name="platform/external/libgsm" />
-  <project path="external/liblzf" name="platform/external/liblzf" />
-  <project path="external/libnfc-nxp" name="platform/external/libnfc-nxp" />
-  <project path="external/libnl-headers" name="platform/external/libnl-headers" />
-  <project path="external/libphonenumber" name="platform/external/libphonenumber" />
-  <project path="external/libpng" name="platform/external/libpng" />
-  <project path="external/libvpx" name="platform/external/libvpx" />
-  <project path="external/mksh" name="platform/external/mksh" />
-  <project path="external/opensans" name="platform_external_opensans" remote="b2g" revision="master" />
-  <project path="external/openssl" name="platform/external/openssl" />
-  <project path="external/protobuf" name="platform/external/protobuf" />
-  <project path="external/safe-iop" name="platform/external/safe-iop" />
-  <project path="external/screencap-gonk" name="screencap-gonk" remote="b2g" revision="master" />
-  <project path="external/skia" name="platform/external/skia" />
-  <project path="external/sonivox" name="platform/external/sonivox" />
-  <project path="external/speex" name="platform/external/speex" />
-  <project path="external/sqlite" name="platform/external/sqlite" />
-  <project path="external/stlport" name="platform/external/stlport" />
-  <project path="external/strace" name="platform/external/strace" />
-  <project path="external/tagsoup" name="platform/external/tagsoup" />
-  <project path="external/tinyalsa" name="platform/external/tinyalsa" />
-  <project path="external/tremolo" name="platform/external/tremolo" />
-  <project path="external/webp" name="platform/external/webp" />
-  <project path="external/webrtc" name="platform/external/webrtc" />
-  <project path="external/wpa_supplicant" name="platform/external/wpa_supplicant" />
-  <project path="external/wpa_supplicant_8" name="platform/external/wpa_supplicant_8" />
-  <project path="external/zlib" name="platform/external/zlib" />
-  <project path="external/yaffs2" name="platform/external/yaffs2" />
-  <project path="frameworks/base" name="platform/frameworks/base" />
-  <project path="frameworks/opt/emoji" name="platform/frameworks/opt/emoji" />
-  <project path="frameworks/support" name="platform/frameworks/support" />
-  <project path="hardware/libhardware" name="platform/hardware/libhardware" />
-  <project path="hardware/libhardware_legacy" name="platform/hardware/libhardware_legacy" />
-  <project path="hardware/ril" name="platform/hardware/ril" />
-  <project path="libcore" name="platform/libcore" />
-  <project path="ndk" name="platform/ndk" />
-  <project path="prebuilt" name="platform/prebuilt" />
-  <project path="system/bluetooth" name="platform/system/bluetooth" />
-  <project path="system/core" name="platform/system/core" />
-  <project path="system/extras" name="platform/system/extras" />
-  <project path="system/media" name="platform/system/media" />
-  <project path="system/netd" name="platform/system/netd" />
-  <project path="system/vold" name="platform/system/vold" />
+  <project path="abi/cpp" name="platform/abi/cpp" revision="6426040f1be4a844082c9769171ce7f5341a5528"/>
+  <project path="bionic" name="platform/bionic" revision="3d11bf0f3f3cf848f6f1e8449bf8736d8d1c78a3"/>
+  <project path="bootable/recovery" name="platform/bootable/recovery" revision="fadc5ac81d6400ebdd041f7d4ea64021596d6b7d"/>
+  <project path="device/common" name="device/common" revision="7d4526582f88808a3194e1a3b304abb369d2745c"/>
+  <project path="device/sample" name="device/sample" revision="ef228b8b377a9663e94be4b1aeb6c2bf7a07d098"/>
+  <project path="external/apache-http" name="platform/external/apache-http" revision="6c9d8c58d3ed710f87c26820d903bb8aad81754f"/>
+  <project path="external/bluetooth/bluez" name="platform/external/bluetooth/bluez" revision="966afbd88f0bfc325bf80274ad2723c238883fa1"/>
+  <project path="external/bluetooth/glib" name="platform/external/bluetooth/glib" revision="1143b9918eab068401b604eb11c3f651f4e38b25"/>
+  <project path="external/bluetooth/hcidump" name="platform/external/bluetooth/hcidump" revision="7322661808c2006b7848e79e6bb72b37fbcf6710"/>
+  <project path="external/bsdiff" name="platform/external/bsdiff" revision="81872540236d9bb15cccf963d05b9de48baa5375"/>
+  <project path="external/busybox" name="platform/external/busybox" remote="linaro" revision="2e461c8029a50d986dfe4ab07ae5a1834b5c40f0"/>
+  <project path="external/bzip2" name="platform/external/bzip2" revision="048dacdca43eed1534689ececcf2781c63e1e4ba"/>
+  <project path="external/dbus" name="platform/external/dbus" revision="537eaff5de9aace3348436166d4cde7adc1e488e"/>
+  <project path="external/dhcpcd" name="platform/external/dhcpcd" revision="ddaa48f57b54b2862b3e6dcf18a44c9647f3baaa"/>
+  <project path="external/dnsmasq" name="platform/external/dnsmasq" revision="f621afad94df46204c25fc2593a19d704d2637f5"/>
+  <project path="external/expat" name="platform/external/expat" revision="6df134250feab71edb5915ecaa6268210bca76c5"/>
+  <project path="external/fdlibm" name="platform/external/fdlibm" revision="988ffeb12a6e044ae3504838ef1fee3fe0716934"/>
+  <project path="external/flac" name="platform/external/flac" revision="5893fbe890f5dab8e4146d2baa4bd2691c0739e0"/>
+  <project path="external/freetype" name="platform/external/freetype" revision="aeb407daf3711a10a27f3bc2223c5eb05158076e"/>
+  <project path="external/giflib" name="platform/external/giflib" revision="b2597268aef084202a8c349d1cc072c03c6e22eb"/>
+  <project path="external/gtest" name="platform/external/gtest" remote="linaro" revision="344e5f3db17615cc853073a02968a603efd39109"/>
+  <project path="external/harfbuzz" name="platform/external/harfbuzz" revision="bae491c03a00757d83ede8d855b7d85d246bde3d"/>
+  <project path="external/icu4c" name="platform/external/icu4c" revision="0fa67b93b831c6636ca18b152a1b1b14cc99b034"/>
+  <project path="external/iptables" name="platform/external/iptables" revision="3b2deb17f065c5664bb25e1a28489e5792eb63ff"/>
+  <project path="external/jhead" name="platform/external/jhead" revision="754078052c687f6721536009c816644c73e4f145"/>
+  <project path="external/jpeg" name="platform/external/jpeg" revision="d4fad7f50f79626455d88523207e05b868819cd8"/>
+  <project path="external/libgsm" name="platform/external/libgsm" revision="5e4516958690b9a1b2c98f88eeecba3edd2dbda4"/>
+  <project path="external/liblzf" name="platform/external/liblzf" revision="6946aa575b0949d045722794850896099d937cbb"/>
+  <project path="external/libnfc-nxp" name="platform/external/libnfc-nxp" revision="533c14450e6239cce8acb74f4e4dea2c89f8f219"/>
+  <project path="external/libnl-headers" name="platform/external/libnl-headers" revision="6ccf7349d61f73ac26a0675d735d903ab919c658"/>
+  <project path="external/libphonenumber" name="platform/external/libphonenumber" revision="d470984844c388d6766c3de6ac64e93e00480fc9"/>
+  <project path="external/libpng" name="platform/external/libpng" revision="84d92c718ab9f48faec0f640747c4b6f7a995607"/>
+  <project path="external/libvpx" name="platform/external/libvpx" revision="3a40da0d96da5c520e7707aa14f48a80956e20d7"/>
+  <project path="external/mksh" name="platform/external/mksh" revision="5155f1c7438ef540d7b25eb70aa1639579795b07"/>
+  <project path="external/opensans" name="platform_external_opensans" remote="b2g" revision="b5b4c226ca1d71e936153cf679dda6d3d60e2354" upstream="v1.0.0"/>
+  <project path="external/openssl" name="platform/external/openssl" revision="ce96fb211b9a44bbd7fb5ef7ed0e6c1244045c2e"/>
+  <project path="external/protobuf" name="platform/external/protobuf" revision="e217977611c52bccde7f7c78e1d3c790c6357431"/>
+  <project path="external/safe-iop" name="platform/external/safe-iop" revision="07073634e2e3aa4f518e36ed5dec3aabc549d5fb"/>
+  <project path="external/screencap-gonk" name="screencap-gonk" remote="b2g" revision="e6403c71e9eca8cb943739d5a0a192deac60fc51" upstream="v1.0.0"/>
+  <project path="external/skia" name="platform/external/skia" revision="5c67a309e16bffe7013defda8f1217b3ce2420b4"/>
+  <project path="external/sonivox" name="platform/external/sonivox" revision="5f9600971859fe072f31b38a51c38157f5f9b381"/>
+  <project path="external/speex" name="platform/external/speex" revision="ebe6230a7f7c69f5a4389f2b09b7b19ef9e94f32"/>
+  <project path="external/sqlite" name="platform/external/sqlite" revision="c999ff8c12a4cf81cb9ad628f47b2720effba5e5"/>
+  <project path="external/stlport" name="platform/external/stlport" revision="a6734e0645fce81c9610de0488b729207bfa576e"/>
+  <project path="external/strace" name="platform/external/strace" revision="c9fd2e5ef7d002e12e7cf2512506c84a9414b0fd"/>
+  <project path="external/tagsoup" name="platform/external/tagsoup" revision="68c2ec9e0acdb3214b7fb91dbab8c9fab8736817"/>
+  <project path="external/tinyalsa" name="platform/external/tinyalsa" revision="495239e683a728957c890c124b239f9b7b8ef5a8"/>
+  <project path="external/tremolo" name="platform/external/tremolo" revision="25bd78d2392dbdc879ae53382cde9d019f79cf6f"/>
+  <project path="external/webp" name="platform/external/webp" revision="88fe2b83c4b9232cd08729556fd0485d6a6a92cd"/>
+  <project path="external/webrtc" name="platform/external/webrtc" revision="4b6dc1ec58105d17dc8c2f550124cc0621dc93b7"/>
+  <project path="external/wpa_supplicant" name="platform/external/wpa_supplicant" revision="a01d37870bbf9892d43e792e5de0683ca41c5497"/>
+  <project path="external/wpa_supplicant_8" name="platform/external/wpa_supplicant_8" revision="648b7492d15bb4efaeebdfdd8bd261563a5f6227"/>
+  <project path="external/zlib" name="platform/external/zlib" revision="69e5801bd16a495e1c1666669fe827b1ddb8d56b"/>
+  <project path="external/yaffs2" name="platform/external/yaffs2" revision="6232e2d5ab34a40d710e4b05ab0ec6e3727804e7"/>
+  <project path="frameworks/base" name="platform/frameworks/base" revision="df331873c8576e0ae34ae1ee3cc258beed373535"/>
+  <project path="frameworks/opt/emoji" name="platform/frameworks/opt/emoji" revision="a95d8db002770469d72dfaf59ff37ac96db29a87"/>
+  <project path="frameworks/support" name="platform/frameworks/support" revision="bfc8e01b7b0d5ea70ce89d0409b72b7f7d540f43"/>
+  <project path="hardware/libhardware" name="platform/hardware/libhardware" revision="a9b677fce432b29ab8f61e13796f34880dc0fe0f"/>
+  <project path="hardware/libhardware_legacy" name="platform/hardware/libhardware_legacy" revision="153d0f1a27e0a157cabb6ca9d0d88248630f5695"/>
+  <project path="hardware/ril" name="platform/hardware/ril" revision="300105d1487f5238940c18792b879793826b61f4"/>
+  <project path="libcore" name="platform/libcore" revision="fc294a48d80d9e2b2ac126edf93ad316f5f6cf72"/>
+  <project path="ndk" name="platform/ndk" revision="2d77f5a05f60029c981f299b222cfe28db18ccf7"/>
+  <project path="prebuilt" name="platform/prebuilt" revision="0e104261b6d33f87e9f86ff4249bcc0306ab278b"/>
+  <project path="system/bluetooth" name="platform/system/bluetooth" revision="2588cd802f322650ed737dfb7a10e9ad94064e99"/>
+  <project path="system/core" name="platform/system/core" revision="c2db4ffb874783220abf967ca4ccd0e6cf1ba57f"/>
+  <project path="system/extras" name="platform/system/extras" revision="fa351ab265957fa8815df3c4ca1f3c105f253e8b"/>
+  <project path="system/media" name="platform/system/media" revision="a8eea50f80327f15cb04bbdfee2d1cfcc4c3ce4a"/>
+  <project path="system/netd" name="platform/system/netd" revision="3c903b555975fa59d6688a0a6417ac7512c202e7"/>
+  <project path="system/vold" name="platform/system/vold" revision="3ad9072a5d6f6bda32123b367545649364e3c11d"/>
 
   <!-- Galaxy Nexus specific things -->
-  <project path="device/samsung/maguro" name="android-device-maguro" remote="b2g" revision="master" />
-  <project path="device/samsung/tuna" name="android-device-tuna" remote="b2g" revision="master" />
-  <project path="device/ti/panda" name="device/ti/panda" />
-  <project path="hardware/invensense" name="platform/hardware/invensense" />
-  <project path="hardware/ti/omap4xxx" name="platform/hardware/ti/omap4xxx" />
-  <project path="hardware/broadcom/wlan" name="platform/hardware/broadcom/wlan" />
+  <project path="device/samsung/maguro" name="android-device-maguro" remote="b2g" revision="8b2a48d1576ac6bcd188eb11080616539bd583b2" upstream="v1.0.0"/>
+  <project path="device/samsung/tuna" name="android-device-tuna" remote="b2g" revision="eec4af6decda1530dcb4c2a09ea53afa59fa26d5" upstream="v1.0.0"/>
+  <project path="device/ti/panda" name="device/ti/panda" revision="3cdcb6d6f87fe454f3bda0e7e6fb174c8893c78d"/>
+  <project path="hardware/invensense" name="platform/hardware/invensense" revision="425eccbf15c25c32cf073595d25ff50e51570c1b"/>
+  <project path="hardware/ti/omap4xxx" name="platform/hardware/ti/omap4xxx" revision="8be8e9a68c96b6cf43c08a58e7ecd7708737c599"/>
+  <project path="hardware/broadcom/wlan" name="platform/hardware/broadcom/wlan" revision="07ef2f509a362cc6a5825d0d19143dc4bd2474e0"/>
 
 </manifest>

--- a/galaxy-s2.xml
+++ b/galaxy-s2.xml
@@ -1,103 +1,96 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote  name="linaro"
-           fetch="git://android.git.linaro.org/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="mozillaorg"
-      fetch="https://git.mozilla.org/releases" />
-  <default revision="refs/tags/android-4.0.4_r1.2"
-           remote="linaro"
-           sync-j="4" />
+  <remote name="aosp" fetch="https://android.googlesource.com/"/>
+  <remote name="b2g" fetch="git://github.com/mozilla-b2g/"/>
+  <remote name="linaro" fetch="git://android.git.linaro.org/"/>
+  <remote name="mozilla" fetch="git://github.com/mozilla/"/>
+  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases"/>
+  <default revision="refs/tags/android-4.0.4_r1.2" remote="linaro" sync-j="4"/>
 
   <!-- Gonk specific things and forks -->
-  <project path="build" name="platform_build" remote="b2g" revision="master">
-    <copyfile src="core/root.mk" dest="Makefile" />
+  <project path="build" name="platform_build" remote="b2g" revision="43434d6cdbf702e6197e0791f19406860284edf6" upstream="v1.0.0">
+    <copyfile src="core/root.mk" dest="Makefile"/>
   </project>
-  <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="gaia.git" remote="mozillaorg" revision="v1.0.0" />
-  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="v1.0.0" />
-  <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
-  <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
-  <project path="external/moztt" name="moztt" remote="b2g" revision="master" />
+  <project path="dalvik" name="fake-dalvik" remote="b2g" revision="ca1f327d5acc198bb4be62fa51db2c039032c9ce" upstream="v1.0.0"/>
+  <project path="gaia" name="gaia.git" remote="mozillaorg" revision="v1.0.0"/>
+  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="v1.0.0"/>
+  <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="f46dac73e6256c25763764d5fa26ac1bdf1417ba" upstream="v1.0.0"/>
+  <project path="rilproxy" name="rilproxy" remote="b2g" revision="f634b3d50effdd42828cc757c01fdbf74e562a36" upstream="v1.0.0"/>
+  <project path="external/moztt" name="moztt" remote="b2g" revision="6ee1f8987ef36d688f97064c003ad57849dfadf2" upstream="v1.0.0"/>
 
   <!-- Stock Android things -->
-  <project path="abi/cpp" name="platform/abi/cpp" />
-  <project path="bionic" name="platform/bionic" />
-  <project path="bootable/recovery" name="platform/bootable/recovery" />
-  <project path="device/common" name="device/common" />
-  <project path="device/sample" name="device/sample" />
-  <project path="external/apache-http" name="platform/external/apache-http" />
-  <project path="external/bluetooth/bluez" name="platform/external/bluetooth/bluez" />
-  <project path="external/bluetooth/glib" name="platform/external/bluetooth/glib" />
-  <project path="external/bluetooth/hcidump" name="platform/external/bluetooth/hcidump" />
-  <project path="external/bsdiff" name="platform/external/bsdiff" />
-  <project path="external/bzip2" name="platform/external/bzip2" />
-  <project path="external/dbus" name="platform/external/dbus" />
-  <project path="external/dhcpcd" name="platform/external/dhcpcd" />
-  <project path="external/dnsmasq" name="platform/external/dnsmasq" />
-  <project path="external/expat" name="platform/external/expat" />
-  <project path="external/fdlibm" name="platform/external/fdlibm" />
-  <project path="external/flac" name="platform/external/flac" />
-  <project path="external/freetype" name="platform/external/freetype" />
-  <project path="external/giflib" name="platform/external/giflib" />
-  <project path="external/gtest" name="platform/external/gtest" remote="linaro" revision="master" />
-  <project path="external/harfbuzz" name="platform/external/harfbuzz" />
-  <project path="external/icu4c" name="platform/external/icu4c" />
-  <project path="external/iptables" name="platform/external/iptables" />
-  <project path="external/jhead" name="platform/external/jhead" />
-  <project path="external/jpeg" name="platform/external/jpeg" />
-  <project path="external/libgsm" name="platform/external/libgsm" />
-  <project path="external/liblzf" name="platform/external/liblzf" />
-  <project path="external/libnfc-nxp" name="platform/external/libnfc-nxp" />
-  <project path="external/libnl-headers" name="platform/external/libnl-headers" />
-  <project path="external/libphonenumber" name="platform/external/libphonenumber" />
-  <project path="external/libpng" name="platform/external/libpng" />
-  <project path="external/libvpx" name="platform/external/libvpx" />
-  <project path="external/mksh" name="platform/external/mksh" />
-  <project path="external/opensans" name="platform_external_opensans" remote="b2g" revision="master" />
-  <project path="external/openssl" name="platform/external/openssl" />
-  <project path="external/protobuf" name="platform/external/protobuf" />
-  <project path="external/safe-iop" name="platform/external/safe-iop" />
-  <project path="external/screencap-gonk" name="screencap-gonk" remote="b2g" revision="master" />
-  <project path="external/sonivox" name="platform/external/sonivox" />
-  <project path="external/speex" name="platform/external/speex" />
-  <project path="external/sqlite" name="platform/external/sqlite" />
-  <project path="external/stlport" name="platform/external/stlport" />
-  <project path="external/strace" name="platform/external/strace" />
-  <project path="external/tagsoup" name="platform/external/tagsoup" />
-  <project path="external/tinyalsa" name="platform/external/tinyalsa" />
-  <project path="external/tremolo" name="platform/external/tremolo" />
-  <project path="external/webp" name="platform/external/webp" />
-  <project path="external/webrtc" name="platform/external/webrtc" />
-  <project path="external/wpa_supplicant" name="platform/external/wpa_supplicant" />
-  <project path="external/wpa_supplicant_8" name="platform/external/wpa_supplicant_8" />
-  <project path="external/zlib" name="platform/external/zlib" />
-  <project path="external/yaffs2" name="platform/external/yaffs2" />
-  <project path="frameworks/base" name="platform/frameworks/base" />
-  <project path="frameworks/opt/emoji" name="platform/frameworks/opt/emoji" />
-  <project path="frameworks/support" name="platform/frameworks/support" />
-  <project path="hardware/libhardware" name="platform/hardware/libhardware" />
-  <project path="hardware/libhardware_legacy" name="platform/hardware/libhardware_legacy" />
-  <project path="hardware/ril" name="platform/hardware/ril" />
-  <project path="libcore" name="platform/libcore" />
-  <project path="ndk" name="platform/ndk" />
-  <project path="prebuilt" name="platform/prebuilt" />
-  <project path="system/bluetooth" name="platform/system/bluetooth" />
-  <project path="system/core" name="platform/system/core" />
-  <project path="system/extras" name="platform/system/extras" />
-  <project path="system/media" name="platform/system/media" />
-  <project path="system/netd" name="platform/system/netd" />
-  <project path="system/vold" name="platform/system/vold" />
+  <project path="abi/cpp" name="platform/abi/cpp" revision="6426040f1be4a844082c9769171ce7f5341a5528"/>
+  <project path="bionic" name="platform/bionic" revision="3d11bf0f3f3cf848f6f1e8449bf8736d8d1c78a3"/>
+  <project path="bootable/recovery" name="platform/bootable/recovery" revision="fadc5ac81d6400ebdd041f7d4ea64021596d6b7d"/>
+  <project path="device/common" name="device/common" revision="7d4526582f88808a3194e1a3b304abb369d2745c"/>
+  <project path="device/sample" name="device/sample" revision="ef228b8b377a9663e94be4b1aeb6c2bf7a07d098"/>
+  <project path="external/apache-http" name="platform/external/apache-http" revision="6c9d8c58d3ed710f87c26820d903bb8aad81754f"/>
+  <project path="external/bluetooth/bluez" name="platform/external/bluetooth/bluez" revision="966afbd88f0bfc325bf80274ad2723c238883fa1"/>
+  <project path="external/bluetooth/glib" name="platform/external/bluetooth/glib" revision="1143b9918eab068401b604eb11c3f651f4e38b25"/>
+  <project path="external/bluetooth/hcidump" name="platform/external/bluetooth/hcidump" revision="7322661808c2006b7848e79e6bb72b37fbcf6710"/>
+  <project path="external/bsdiff" name="platform/external/bsdiff" revision="81872540236d9bb15cccf963d05b9de48baa5375"/>
+  <project path="external/bzip2" name="platform/external/bzip2" revision="048dacdca43eed1534689ececcf2781c63e1e4ba"/>
+  <project path="external/dbus" name="platform/external/dbus" revision="537eaff5de9aace3348436166d4cde7adc1e488e"/>
+  <project path="external/dhcpcd" name="platform/external/dhcpcd" revision="ddaa48f57b54b2862b3e6dcf18a44c9647f3baaa"/>
+  <project path="external/dnsmasq" name="platform/external/dnsmasq" revision="f621afad94df46204c25fc2593a19d704d2637f5"/>
+  <project path="external/expat" name="platform/external/expat" revision="6df134250feab71edb5915ecaa6268210bca76c5"/>
+  <project path="external/fdlibm" name="platform/external/fdlibm" revision="988ffeb12a6e044ae3504838ef1fee3fe0716934"/>
+  <project path="external/flac" name="platform/external/flac" revision="5893fbe890f5dab8e4146d2baa4bd2691c0739e0"/>
+  <project path="external/freetype" name="platform/external/freetype" revision="aeb407daf3711a10a27f3bc2223c5eb05158076e"/>
+  <project path="external/giflib" name="platform/external/giflib" revision="b2597268aef084202a8c349d1cc072c03c6e22eb"/>
+  <project path="external/gtest" name="platform/external/gtest" remote="linaro" revision="344e5f3db17615cc853073a02968a603efd39109"/>
+  <project path="external/harfbuzz" name="platform/external/harfbuzz" revision="bae491c03a00757d83ede8d855b7d85d246bde3d"/>
+  <project path="external/icu4c" name="platform/external/icu4c" revision="0fa67b93b831c6636ca18b152a1b1b14cc99b034"/>
+  <project path="external/iptables" name="platform/external/iptables" revision="3b2deb17f065c5664bb25e1a28489e5792eb63ff"/>
+  <project path="external/jhead" name="platform/external/jhead" revision="754078052c687f6721536009c816644c73e4f145"/>
+  <project path="external/jpeg" name="platform/external/jpeg" revision="d4fad7f50f79626455d88523207e05b868819cd8"/>
+  <project path="external/libgsm" name="platform/external/libgsm" revision="5e4516958690b9a1b2c98f88eeecba3edd2dbda4"/>
+  <project path="external/liblzf" name="platform/external/liblzf" revision="6946aa575b0949d045722794850896099d937cbb"/>
+  <project path="external/libnfc-nxp" name="platform/external/libnfc-nxp" revision="533c14450e6239cce8acb74f4e4dea2c89f8f219"/>
+  <project path="external/libnl-headers" name="platform/external/libnl-headers" revision="6ccf7349d61f73ac26a0675d735d903ab919c658"/>
+  <project path="external/libphonenumber" name="platform/external/libphonenumber" revision="d470984844c388d6766c3de6ac64e93e00480fc9"/>
+  <project path="external/libpng" name="platform/external/libpng" revision="84d92c718ab9f48faec0f640747c4b6f7a995607"/>
+  <project path="external/libvpx" name="platform/external/libvpx" revision="3a40da0d96da5c520e7707aa14f48a80956e20d7"/>
+  <project path="external/mksh" name="platform/external/mksh" revision="5155f1c7438ef540d7b25eb70aa1639579795b07"/>
+  <project path="external/opensans" name="platform_external_opensans" remote="b2g" revision="b5b4c226ca1d71e936153cf679dda6d3d60e2354" upstream="v1.0.0"/>
+  <project path="external/openssl" name="platform/external/openssl" revision="ce96fb211b9a44bbd7fb5ef7ed0e6c1244045c2e"/>
+  <project path="external/protobuf" name="platform/external/protobuf" revision="e217977611c52bccde7f7c78e1d3c790c6357431"/>
+  <project path="external/safe-iop" name="platform/external/safe-iop" revision="07073634e2e3aa4f518e36ed5dec3aabc549d5fb"/>
+  <project path="external/screencap-gonk" name="screencap-gonk" remote="b2g" revision="e6403c71e9eca8cb943739d5a0a192deac60fc51" upstream="v1.0.0"/>
+  <project path="external/sonivox" name="platform/external/sonivox" revision="5f9600971859fe072f31b38a51c38157f5f9b381"/>
+  <project path="external/speex" name="platform/external/speex" revision="ebe6230a7f7c69f5a4389f2b09b7b19ef9e94f32"/>
+  <project path="external/sqlite" name="platform/external/sqlite" revision="c999ff8c12a4cf81cb9ad628f47b2720effba5e5"/>
+  <project path="external/stlport" name="platform/external/stlport" revision="a6734e0645fce81c9610de0488b729207bfa576e"/>
+  <project path="external/strace" name="platform/external/strace" revision="c9fd2e5ef7d002e12e7cf2512506c84a9414b0fd"/>
+  <project path="external/tagsoup" name="platform/external/tagsoup" revision="68c2ec9e0acdb3214b7fb91dbab8c9fab8736817"/>
+  <project path="external/tinyalsa" name="platform/external/tinyalsa" revision="495239e683a728957c890c124b239f9b7b8ef5a8"/>
+  <project path="external/tremolo" name="platform/external/tremolo" revision="25bd78d2392dbdc879ae53382cde9d019f79cf6f"/>
+  <project path="external/webp" name="platform/external/webp" revision="88fe2b83c4b9232cd08729556fd0485d6a6a92cd"/>
+  <project path="external/webrtc" name="platform/external/webrtc" revision="4b6dc1ec58105d17dc8c2f550124cc0621dc93b7"/>
+  <project path="external/wpa_supplicant" name="platform/external/wpa_supplicant" revision="a01d37870bbf9892d43e792e5de0683ca41c5497"/>
+  <project path="external/wpa_supplicant_8" name="platform/external/wpa_supplicant_8" revision="648b7492d15bb4efaeebdfdd8bd261563a5f6227"/>
+  <project path="external/zlib" name="platform/external/zlib" revision="69e5801bd16a495e1c1666669fe827b1ddb8d56b"/>
+  <project path="external/yaffs2" name="platform/external/yaffs2" revision="6232e2d5ab34a40d710e4b05ab0ec6e3727804e7"/>
+  <project path="frameworks/base" name="platform/frameworks/base" revision="df331873c8576e0ae34ae1ee3cc258beed373535"/>
+  <project path="frameworks/opt/emoji" name="platform/frameworks/opt/emoji" revision="a95d8db002770469d72dfaf59ff37ac96db29a87"/>
+  <project path="frameworks/support" name="platform/frameworks/support" revision="bfc8e01b7b0d5ea70ce89d0409b72b7f7d540f43"/>
+  <project path="hardware/libhardware" name="platform/hardware/libhardware" revision="a9b677fce432b29ab8f61e13796f34880dc0fe0f"/>
+  <project path="hardware/libhardware_legacy" name="platform/hardware/libhardware_legacy" revision="153d0f1a27e0a157cabb6ca9d0d88248630f5695"/>
+  <project path="hardware/ril" name="platform/hardware/ril" revision="300105d1487f5238940c18792b879793826b61f4"/>
+  <project path="libcore" name="platform/libcore" revision="fc294a48d80d9e2b2ac126edf93ad316f5f6cf72"/>
+  <project path="ndk" name="platform/ndk" revision="2d77f5a05f60029c981f299b222cfe28db18ccf7"/>
+  <project path="prebuilt" name="platform/prebuilt" revision="0e104261b6d33f87e9f86ff4249bcc0306ab278b"/>
+  <project path="system/bluetooth" name="platform/system/bluetooth" revision="2588cd802f322650ed737dfb7a10e9ad94064e99"/>
+  <project path="system/core" name="platform/system/core" revision="c2db4ffb874783220abf967ca4ccd0e6cf1ba57f"/>
+  <project path="system/extras" name="platform/system/extras" revision="fa351ab265957fa8815df3c4ca1f3c105f253e8b"/>
+  <project path="system/media" name="platform/system/media" revision="a8eea50f80327f15cb04bbdfee2d1cfcc4c3ce4a"/>
+  <project path="system/netd" name="platform/system/netd" revision="3c903b555975fa59d6688a0a6417ac7512c202e7"/>
+  <project path="system/vold" name="platform/system/vold" revision="3ad9072a5d6f6bda32123b367545649364e3c11d"/>
 
   <!-- Galaxy S2 things -->
-  <project path="device/samsung/galaxys2" name="android-device-galaxys2" remote="b2g" revision="master" />
-  <project path="hardware/broadcom/wlan" name="platform/hardware/broadcom/wlan" />
-  <project path="external/skia" name="skia-b2g-sgs2" remote="b2g" revision="master" />
+  <project path="device/samsung/galaxys2" name="android-device-galaxys2" remote="b2g" revision="987b9c9140e838c0972df6185549e61d2d067e47" upstream="v1.0.0"/>
+  <project path="hardware/broadcom/wlan" name="platform/hardware/broadcom/wlan" revision="07ef2f509a362cc6a5825d0d19143dc4bd2474e0"/>
+  <project path="external/skia" name="skia-b2g-sgs2" remote="b2g" revision="e2d7caf0363dec74d77f7e7adbe5b4cce0c6524c" upstream="v1.0.0"/>
 
 </manifest>

--- a/nexus-s-4g.xml
+++ b/nexus-s-4g.xml
@@ -1,105 +1,98 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote  name="linaro"
-           fetch="git://android.git.linaro.org/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="mozillaorg"
-      fetch="https://git.mozilla.org/releases" />
-  <default revision="refs/tags/android-4.0.4_r1.2"
-           remote="linaro"
-           sync-j="4" />
+  <remote name="aosp" fetch="https://android.googlesource.com/"/>
+  <remote name="b2g" fetch="git://github.com/mozilla-b2g/"/>
+  <remote name="linaro" fetch="git://android.git.linaro.org/"/>
+  <remote name="mozilla" fetch="git://github.com/mozilla/"/>
+  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases"/>
+  <default revision="refs/tags/android-4.0.4_r1.2" remote="linaro" sync-j="4"/>
 
   <!-- Gonk specific things and forks -->
-  <project path="build" name="platform_build" remote="b2g" revision="master">
-    <copyfile src="core/root.mk" dest="Makefile" />
+  <project path="build" name="platform_build" remote="b2g" revision="43434d6cdbf702e6197e0791f19406860284edf6" upstream="v1.0.0">
+    <copyfile src="core/root.mk" dest="Makefile"/>
   </project>
-  <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="gaia.git" remote="mozillaorg" revision="v1.0.0" />
-  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="v1.0.0" />
-  <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
-  <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
-  <project path="external/moztt" name="moztt" remote="b2g" revision="master" />
+  <project path="dalvik" name="fake-dalvik" remote="b2g" revision="ca1f327d5acc198bb4be62fa51db2c039032c9ce" upstream="v1.0.0"/>
+  <project path="gaia" name="gaia.git" remote="mozillaorg" revision="v1.0.0"/>
+  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="v1.0.0"/>
+  <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="f46dac73e6256c25763764d5fa26ac1bdf1417ba" upstream="v1.0.0"/>
+  <project path="rilproxy" name="rilproxy" remote="b2g" revision="f634b3d50effdd42828cc757c01fdbf74e562a36" upstream="v1.0.0"/>
+  <project path="external/moztt" name="moztt" remote="b2g" revision="6ee1f8987ef36d688f97064c003ad57849dfadf2" upstream="v1.0.0"/>
 
   <!-- Stock Android things -->
-  <project path="abi/cpp" name="platform/abi/cpp" />
-  <project path="bionic" name="platform/bionic" />
-  <project path="bootable/recovery" name="platform/bootable/recovery" />
-  <project path="development" name="platform/development" />
-  <project path="device/common" name="device/common" />
-  <project path="device/sample" name="device/sample" />
-  <project path="external/apache-http" name="platform/external/apache-http" />
-  <project path="external/bluetooth/bluez" name="platform/external/bluetooth/bluez" />
-  <project path="external/bluetooth/glib" name="platform/external/bluetooth/glib" />
-  <project path="external/bluetooth/hcidump" name="platform/external/bluetooth/hcidump" />
-  <project path="external/bsdiff" name="platform/external/bsdiff" />
-  <project path="external/bzip2" name="platform/external/bzip2" />
-  <project path="external/dbus" name="platform/external/dbus" />
-  <project path="external/dhcpcd" name="platform/external/dhcpcd" />
-  <project path="external/dnsmasq" name="platform/external/dnsmasq" />
-  <project path="external/expat" name="platform/external/expat" />
-  <project path="external/fdlibm" name="platform/external/fdlibm" />
-  <project path="external/flac" name="platform/external/flac" />
-  <project path="external/freetype" name="platform/external/freetype" />
-  <project path="external/giflib" name="platform/external/giflib" />
-  <project path="external/gtest" name="platform/external/gtest" remote="aosp" revision="master" />
-  <project path="external/harfbuzz" name="platform/external/harfbuzz" />
-  <project path="external/icu4c" name="platform/external/icu4c" />
-  <project path="external/iptables" name="platform/external/iptables" />
-  <project path="external/jhead" name="platform/external/jhead" />
-  <project path="external/jpeg" name="platform/external/jpeg" />
-  <project path="external/libgsm" name="platform/external/libgsm" />
-  <project path="external/liblzf" name="platform/external/liblzf" />
-  <project path="external/libnfc-nxp" name="platform/external/libnfc-nxp" />
-  <project path="external/libnl-headers" name="platform/external/libnl-headers" />
-  <project path="external/libphonenumber" name="platform/external/libphonenumber" />
-  <project path="external/libpng" name="platform/external/libpng" />
-  <project path="external/libvpx" name="platform/external/libvpx" />
-  <project path="external/mksh" name="platform/external/mksh" />
-  <project path="external/opensans" name="platform_external_opensans" remote="b2g" revision="master" />
-  <project path="external/openssl" name="platform/external/openssl" />
-  <project path="external/protobuf" name="platform/external/protobuf" />
-  <project path="external/safe-iop" name="platform/external/safe-iop" />
-  <project path="external/screencap-gonk" name="screencap-gonk" remote="b2g" revision="master" />
-  <project path="external/skia" name="platform/external/skia" />
-  <project path="external/sonivox" name="platform/external/sonivox" />
-  <project path="external/speex" name="platform/external/speex" />
-  <project path="external/sqlite" name="platform/external/sqlite" />
-  <project path="external/stlport" name="platform/external/stlport" />
-  <project path="external/strace" name="platform/external/strace" />
-  <project path="external/tagsoup" name="platform/external/tagsoup" />
-  <project path="external/tinyalsa" name="platform/external/tinyalsa" />
-  <project path="external/tremolo" name="platform/external/tremolo" />
-  <project path="external/webp" name="platform/external/webp" />
-  <project path="external/webrtc" name="platform/external/webrtc" />
-  <project path="external/wpa_supplicant" name="platform/external/wpa_supplicant" />
-  <project path="external/wpa_supplicant_8" name="platform/external/wpa_supplicant_8" />
-  <project path="external/zlib" name="platform/external/zlib" />
-  <project path="external/yaffs2" name="platform/external/yaffs2" />
-  <project path="frameworks/base" name="platform/frameworks/base" />
-  <project path="frameworks/opt/emoji" name="platform/frameworks/opt/emoji" />
-  <project path="frameworks/support" name="platform/frameworks/support" />
-  <project path="hardware/libhardware" name="platform/hardware/libhardware" />
-  <project path="hardware/libhardware_legacy" name="platform/hardware/libhardware_legacy" />
-  <project path="hardware/ril" name="platform/hardware/ril" />
-  <project path="libcore" name="platform/libcore" />
-  <project path="ndk" name="platform/ndk" />
-  <project path="prebuilt" name="platform/prebuilt" />
-  <project path="system/bluetooth" name="platform/system/bluetooth" />
-  <project path="system/core" name="platform/system/core" />
-  <project path="system/extras" name="platform/system/extras" />
-  <project path="system/media" name="platform/system/media" />
-  <project path="system/netd" name="platform/system/netd" />
-  <project path="system/vold" name="platform/system/vold" />
+  <project path="abi/cpp" name="platform/abi/cpp" revision="6426040f1be4a844082c9769171ce7f5341a5528"/>
+  <project path="bionic" name="platform/bionic" revision="3d11bf0f3f3cf848f6f1e8449bf8736d8d1c78a3"/>
+  <project path="bootable/recovery" name="platform/bootable/recovery" revision="fadc5ac81d6400ebdd041f7d4ea64021596d6b7d"/>
+  <project path="development" name="platform/development" revision="885cc0e7d4e7c5f02b6bc6419d93e5d60a3469f3"/>
+  <project path="device/common" name="device/common" revision="7d4526582f88808a3194e1a3b304abb369d2745c"/>
+  <project path="device/sample" name="device/sample" revision="ef228b8b377a9663e94be4b1aeb6c2bf7a07d098"/>
+  <project path="external/apache-http" name="platform/external/apache-http" revision="6c9d8c58d3ed710f87c26820d903bb8aad81754f"/>
+  <project path="external/bluetooth/bluez" name="platform/external/bluetooth/bluez" revision="966afbd88f0bfc325bf80274ad2723c238883fa1"/>
+  <project path="external/bluetooth/glib" name="platform/external/bluetooth/glib" revision="1143b9918eab068401b604eb11c3f651f4e38b25"/>
+  <project path="external/bluetooth/hcidump" name="platform/external/bluetooth/hcidump" revision="7322661808c2006b7848e79e6bb72b37fbcf6710"/>
+  <project path="external/bsdiff" name="platform/external/bsdiff" revision="81872540236d9bb15cccf963d05b9de48baa5375"/>
+  <project path="external/bzip2" name="platform/external/bzip2" revision="048dacdca43eed1534689ececcf2781c63e1e4ba"/>
+  <project path="external/dbus" name="platform/external/dbus" revision="537eaff5de9aace3348436166d4cde7adc1e488e"/>
+  <project path="external/dhcpcd" name="platform/external/dhcpcd" revision="ddaa48f57b54b2862b3e6dcf18a44c9647f3baaa"/>
+  <project path="external/dnsmasq" name="platform/external/dnsmasq" revision="f621afad94df46204c25fc2593a19d704d2637f5"/>
+  <project path="external/expat" name="platform/external/expat" revision="6df134250feab71edb5915ecaa6268210bca76c5"/>
+  <project path="external/fdlibm" name="platform/external/fdlibm" revision="988ffeb12a6e044ae3504838ef1fee3fe0716934"/>
+  <project path="external/flac" name="platform/external/flac" revision="5893fbe890f5dab8e4146d2baa4bd2691c0739e0"/>
+  <project path="external/freetype" name="platform/external/freetype" revision="aeb407daf3711a10a27f3bc2223c5eb05158076e"/>
+  <project path="external/giflib" name="platform/external/giflib" revision="b2597268aef084202a8c349d1cc072c03c6e22eb"/>
+  <project path="external/gtest" name="platform/external/gtest" remote="aosp" revision="344e5f3db17615cc853073a02968a603efd39109"/>
+  <project path="external/harfbuzz" name="platform/external/harfbuzz" revision="bae491c03a00757d83ede8d855b7d85d246bde3d"/>
+  <project path="external/icu4c" name="platform/external/icu4c" revision="0fa67b93b831c6636ca18b152a1b1b14cc99b034"/>
+  <project path="external/iptables" name="platform/external/iptables" revision="3b2deb17f065c5664bb25e1a28489e5792eb63ff"/>
+  <project path="external/jhead" name="platform/external/jhead" revision="754078052c687f6721536009c816644c73e4f145"/>
+  <project path="external/jpeg" name="platform/external/jpeg" revision="d4fad7f50f79626455d88523207e05b868819cd8"/>
+  <project path="external/libgsm" name="platform/external/libgsm" revision="5e4516958690b9a1b2c98f88eeecba3edd2dbda4"/>
+  <project path="external/liblzf" name="platform/external/liblzf" revision="6946aa575b0949d045722794850896099d937cbb"/>
+  <project path="external/libnfc-nxp" name="platform/external/libnfc-nxp" revision="533c14450e6239cce8acb74f4e4dea2c89f8f219"/>
+  <project path="external/libnl-headers" name="platform/external/libnl-headers" revision="6ccf7349d61f73ac26a0675d735d903ab919c658"/>
+  <project path="external/libphonenumber" name="platform/external/libphonenumber" revision="d470984844c388d6766c3de6ac64e93e00480fc9"/>
+  <project path="external/libpng" name="platform/external/libpng" revision="84d92c718ab9f48faec0f640747c4b6f7a995607"/>
+  <project path="external/libvpx" name="platform/external/libvpx" revision="3a40da0d96da5c520e7707aa14f48a80956e20d7"/>
+  <project path="external/mksh" name="platform/external/mksh" revision="5155f1c7438ef540d7b25eb70aa1639579795b07"/>
+  <project path="external/opensans" name="platform_external_opensans" remote="b2g" revision="b5b4c226ca1d71e936153cf679dda6d3d60e2354" upstream="v1.0.0"/>
+  <project path="external/openssl" name="platform/external/openssl" revision="ce96fb211b9a44bbd7fb5ef7ed0e6c1244045c2e"/>
+  <project path="external/protobuf" name="platform/external/protobuf" revision="e217977611c52bccde7f7c78e1d3c790c6357431"/>
+  <project path="external/safe-iop" name="platform/external/safe-iop" revision="07073634e2e3aa4f518e36ed5dec3aabc549d5fb"/>
+  <project path="external/screencap-gonk" name="screencap-gonk" remote="b2g" revision="e6403c71e9eca8cb943739d5a0a192deac60fc51" upstream="v1.0.0"/>
+  <project path="external/skia" name="platform/external/skia" revision="5c67a309e16bffe7013defda8f1217b3ce2420b4"/>
+  <project path="external/sonivox" name="platform/external/sonivox" revision="5f9600971859fe072f31b38a51c38157f5f9b381"/>
+  <project path="external/speex" name="platform/external/speex" revision="ebe6230a7f7c69f5a4389f2b09b7b19ef9e94f32"/>
+  <project path="external/sqlite" name="platform/external/sqlite" revision="c999ff8c12a4cf81cb9ad628f47b2720effba5e5"/>
+  <project path="external/stlport" name="platform/external/stlport" revision="a6734e0645fce81c9610de0488b729207bfa576e"/>
+  <project path="external/strace" name="platform/external/strace" revision="c9fd2e5ef7d002e12e7cf2512506c84a9414b0fd"/>
+  <project path="external/tagsoup" name="platform/external/tagsoup" revision="68c2ec9e0acdb3214b7fb91dbab8c9fab8736817"/>
+  <project path="external/tinyalsa" name="platform/external/tinyalsa" revision="495239e683a728957c890c124b239f9b7b8ef5a8"/>
+  <project path="external/tremolo" name="platform/external/tremolo" revision="25bd78d2392dbdc879ae53382cde9d019f79cf6f"/>
+  <project path="external/webp" name="platform/external/webp" revision="88fe2b83c4b9232cd08729556fd0485d6a6a92cd"/>
+  <project path="external/webrtc" name="platform/external/webrtc" revision="4b6dc1ec58105d17dc8c2f550124cc0621dc93b7"/>
+  <project path="external/wpa_supplicant" name="platform/external/wpa_supplicant" revision="a01d37870bbf9892d43e792e5de0683ca41c5497"/>
+  <project path="external/wpa_supplicant_8" name="platform/external/wpa_supplicant_8" revision="648b7492d15bb4efaeebdfdd8bd261563a5f6227"/>
+  <project path="external/zlib" name="platform/external/zlib" revision="69e5801bd16a495e1c1666669fe827b1ddb8d56b"/>
+  <project path="external/yaffs2" name="platform/external/yaffs2" revision="6232e2d5ab34a40d710e4b05ab0ec6e3727804e7"/>
+  <project path="frameworks/base" name="platform/frameworks/base" revision="df331873c8576e0ae34ae1ee3cc258beed373535"/>
+  <project path="frameworks/opt/emoji" name="platform/frameworks/opt/emoji" revision="a95d8db002770469d72dfaf59ff37ac96db29a87"/>
+  <project path="frameworks/support" name="platform/frameworks/support" revision="bfc8e01b7b0d5ea70ce89d0409b72b7f7d540f43"/>
+  <project path="hardware/libhardware" name="platform/hardware/libhardware" revision="a9b677fce432b29ab8f61e13796f34880dc0fe0f"/>
+  <project path="hardware/libhardware_legacy" name="platform/hardware/libhardware_legacy" revision="153d0f1a27e0a157cabb6ca9d0d88248630f5695"/>
+  <project path="hardware/ril" name="platform/hardware/ril" revision="300105d1487f5238940c18792b879793826b61f4"/>
+  <project path="libcore" name="platform/libcore" revision="fc294a48d80d9e2b2ac126edf93ad316f5f6cf72"/>
+  <project path="ndk" name="platform/ndk" revision="2d77f5a05f60029c981f299b222cfe28db18ccf7"/>
+  <project path="prebuilt" name="platform/prebuilt" revision="0e104261b6d33f87e9f86ff4249bcc0306ab278b"/>
+  <project path="system/bluetooth" name="platform/system/bluetooth" revision="2588cd802f322650ed737dfb7a10e9ad94064e99"/>
+  <project path="system/core" name="platform/system/core" revision="c2db4ffb874783220abf967ca4ccd0e6cf1ba57f"/>
+  <project path="system/extras" name="platform/system/extras" revision="fa351ab265957fa8815df3c4ca1f3c105f253e8b"/>
+  <project path="system/media" name="platform/system/media" revision="a8eea50f80327f15cb04bbdfee2d1cfcc4c3ce4a"/>
+  <project path="system/netd" name="platform/system/netd" revision="3c903b555975fa59d6688a0a6417ac7512c202e7"/>
+  <project path="system/vold" name="platform/system/vold" revision="3ad9072a5d6f6bda32123b367545649364e3c11d"/>
 
   <!-- Nexus S 4G specific things -->
-  <project path="device/samsung/crespo" name="android-device-crespo" remote="b2g" revision="master" />
-  <project path="device/samsung/crespo4g" name="android-device-crespo4g" remote="b2g" revision="ics-b2g" />
-  <project path="hardware/broadcom/wlan" name="platform/hardware/broadcom/wlan" />
+  <project path="device/samsung/crespo" name="android-device-crespo" remote="b2g" revision="5c539db3b799c2faa8966340ed2fe9ea8c52ec04" upstream="v1.0.0"/>
+  <project path="device/samsung/crespo4g" name="android-device-crespo4g" remote="b2g" revision="a66e3197af43ec6b1850693046230bfc10fdc005" upstream="v1.0.0"/>
+  <project path="hardware/broadcom/wlan" name="platform/hardware/broadcom/wlan" revision="07ef2f509a362cc6a5825d0d19143dc4bd2474e0"/>
 
 </manifest>

--- a/nexus-s.xml
+++ b/nexus-s.xml
@@ -1,103 +1,96 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote  name="linaro"
-           fetch="git://android.git.linaro.org/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="mozillaorg" 
-      fetch="https://git.mozilla.org/releases" />
-  <default revision="refs/tags/android-4.0.4_r1.2"
-           remote="linaro"
-           sync-j="4" />
+  <remote name="aosp" fetch="https://android.googlesource.com/"/>
+  <remote name="b2g" fetch="git://github.com/mozilla-b2g/"/>
+  <remote name="linaro" fetch="git://android.git.linaro.org/"/>
+  <remote name="mozilla" fetch="git://github.com/mozilla/"/>
+  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases"/>
+  <default revision="refs/tags/android-4.0.4_r1.2" remote="linaro" sync-j="4"/>
 
   <!-- Gonk specific things and forks -->
-  <project path="build" name="platform_build" remote="b2g" revision="master">
-    <copyfile src="core/root.mk" dest="Makefile" />
+  <project path="build" name="platform_build" remote="b2g" revision="43434d6cdbf702e6197e0791f19406860284edf6" upstream="v1.0.0">
+    <copyfile src="core/root.mk" dest="Makefile"/>
   </project>
-  <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="gaia.git" remote="mozillaorg" revision="v1.0.0" />
-  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="v1.0.0" />
-  <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
-  <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
-  <project path="external/moztt" name="moztt" remote="b2g" revision="master" />
+  <project path="dalvik" name="fake-dalvik" remote="b2g" revision="ca1f327d5acc198bb4be62fa51db2c039032c9ce" upstream="v1.0.0"/>
+  <project path="gaia" name="gaia.git" remote="mozillaorg" revision="v1.0.0"/>
+  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="v1.0.0"/>
+  <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="f46dac73e6256c25763764d5fa26ac1bdf1417ba" upstream="v1.0.0"/>
+  <project path="rilproxy" name="rilproxy" remote="b2g" revision="f634b3d50effdd42828cc757c01fdbf74e562a36" upstream="v1.0.0"/>
+  <project path="external/moztt" name="moztt" remote="b2g" revision="6ee1f8987ef36d688f97064c003ad57849dfadf2" upstream="v1.0.0"/>
 
   <!-- Stock Android things -->
-  <project path="abi/cpp" name="platform/abi/cpp" />
-  <project path="bionic" name="platform/bionic" />
-  <project path="bootable/recovery" name="platform/bootable/recovery" />
-  <project path="device/common" name="device/common" />
-  <project path="device/sample" name="device/sample" />
-  <project path="external/apache-http" name="platform/external/apache-http" />
-  <project path="external/bluetooth/bluez" name="platform/external/bluetooth/bluez" />
-  <project path="external/bluetooth/glib" name="platform/external/bluetooth/glib" />
-  <project path="external/bluetooth/hcidump" name="platform/external/bluetooth/hcidump" />
-  <project path="external/bsdiff" name="platform/external/bsdiff" />
-  <project path="external/bzip2" name="platform/external/bzip2" />
-  <project path="external/dbus" name="platform/external/dbus" />
-  <project path="external/dhcpcd" name="platform/external/dhcpcd" />
-  <project path="external/dnsmasq" name="platform/external/dnsmasq" />
-  <project path="external/expat" name="platform/external/expat" />
-  <project path="external/fdlibm" name="platform/external/fdlibm" />
-  <project path="external/flac" name="platform/external/flac" />
-  <project path="external/freetype" name="platform/external/freetype" />
-  <project path="external/giflib" name="platform/external/giflib" />
-  <project path="external/gtest" name="platform/external/gtest" remote="aosp" revision="master" />
-  <project path="external/harfbuzz" name="platform/external/harfbuzz" />
-  <project path="external/icu4c" name="platform/external/icu4c" />
-  <project path="external/iptables" name="platform/external/iptables" />
-  <project path="external/jhead" name="platform/external/jhead" />
-  <project path="external/jpeg" name="platform/external/jpeg" />
-  <project path="external/libgsm" name="platform/external/libgsm" />
-  <project path="external/liblzf" name="platform/external/liblzf" />
-  <project path="external/libnfc-nxp" name="platform/external/libnfc-nxp" />
-  <project path="external/libnl-headers" name="platform/external/libnl-headers" />
-  <project path="external/libphonenumber" name="platform/external/libphonenumber" />
-  <project path="external/libpng" name="platform/external/libpng" />
-  <project path="external/libvpx" name="platform/external/libvpx" />
-  <project path="external/mksh" name="platform/external/mksh" />
-  <project path="external/opensans" name="platform_external_opensans" remote="b2g" revision="master" />
-  <project path="external/openssl" name="platform/external/openssl" />
-  <project path="external/protobuf" name="platform/external/protobuf" />
-  <project path="external/safe-iop" name="platform/external/safe-iop" />
-  <project path="external/screencap-gonk" name="screencap-gonk" remote="b2g" revision="master" />
-  <project path="external/skia" name="platform/external/skia" />
-  <project path="external/sonivox" name="platform/external/sonivox" />
-  <project path="external/speex" name="platform/external/speex" />
-  <project path="external/sqlite" name="platform/external/sqlite" />
-  <project path="external/stlport" name="platform/external/stlport" />
-  <project path="external/strace" name="platform/external/strace" />
-  <project path="external/tagsoup" name="platform/external/tagsoup" />
-  <project path="external/tinyalsa" name="platform/external/tinyalsa" />
-  <project path="external/tremolo" name="platform/external/tremolo" />
-  <project path="external/webp" name="platform/external/webp" />
-  <project path="external/webrtc" name="platform/external/webrtc" />
-  <project path="external/wpa_supplicant" name="platform/external/wpa_supplicant" />
-  <project path="external/wpa_supplicant_8" name="platform/external/wpa_supplicant_8" />
-  <project path="external/zlib" name="platform/external/zlib" />
-  <project path="external/yaffs2" name="platform/external/yaffs2" />
-  <project path="frameworks/base" name="platform/frameworks/base" />
-  <project path="frameworks/opt/emoji" name="platform/frameworks/opt/emoji" />
-  <project path="frameworks/support" name="platform/frameworks/support" />
-  <project path="hardware/libhardware" name="platform/hardware/libhardware" />
-  <project path="hardware/libhardware_legacy" name="platform/hardware/libhardware_legacy" />
-  <project path="hardware/ril" name="platform/hardware/ril" />
-  <project path="libcore" name="platform/libcore" />
-  <project path="ndk" name="platform/ndk" />
-  <project path="prebuilt" name="platform/prebuilt" />
-  <project path="system/bluetooth" name="platform/system/bluetooth" />
-  <project path="system/core" name="platform/system/core" />
-  <project path="system/extras" name="platform/system/extras" />
-  <project path="system/media" name="platform/system/media" />
-  <project path="system/netd" name="platform/system/netd" />
-  <project path="system/vold" name="platform/system/vold" />
+  <project path="abi/cpp" name="platform/abi/cpp" revision="6426040f1be4a844082c9769171ce7f5341a5528"/>
+  <project path="bionic" name="platform/bionic" revision="3d11bf0f3f3cf848f6f1e8449bf8736d8d1c78a3"/>
+  <project path="bootable/recovery" name="platform/bootable/recovery" revision="fadc5ac81d6400ebdd041f7d4ea64021596d6b7d"/>
+  <project path="device/common" name="device/common" revision="7d4526582f88808a3194e1a3b304abb369d2745c"/>
+  <project path="device/sample" name="device/sample" revision="ef228b8b377a9663e94be4b1aeb6c2bf7a07d098"/>
+  <project path="external/apache-http" name="platform/external/apache-http" revision="6c9d8c58d3ed710f87c26820d903bb8aad81754f"/>
+  <project path="external/bluetooth/bluez" name="platform/external/bluetooth/bluez" revision="966afbd88f0bfc325bf80274ad2723c238883fa1"/>
+  <project path="external/bluetooth/glib" name="platform/external/bluetooth/glib" revision="1143b9918eab068401b604eb11c3f651f4e38b25"/>
+  <project path="external/bluetooth/hcidump" name="platform/external/bluetooth/hcidump" revision="7322661808c2006b7848e79e6bb72b37fbcf6710"/>
+  <project path="external/bsdiff" name="platform/external/bsdiff" revision="81872540236d9bb15cccf963d05b9de48baa5375"/>
+  <project path="external/bzip2" name="platform/external/bzip2" revision="048dacdca43eed1534689ececcf2781c63e1e4ba"/>
+  <project path="external/dbus" name="platform/external/dbus" revision="537eaff5de9aace3348436166d4cde7adc1e488e"/>
+  <project path="external/dhcpcd" name="platform/external/dhcpcd" revision="ddaa48f57b54b2862b3e6dcf18a44c9647f3baaa"/>
+  <project path="external/dnsmasq" name="platform/external/dnsmasq" revision="f621afad94df46204c25fc2593a19d704d2637f5"/>
+  <project path="external/expat" name="platform/external/expat" revision="6df134250feab71edb5915ecaa6268210bca76c5"/>
+  <project path="external/fdlibm" name="platform/external/fdlibm" revision="988ffeb12a6e044ae3504838ef1fee3fe0716934"/>
+  <project path="external/flac" name="platform/external/flac" revision="5893fbe890f5dab8e4146d2baa4bd2691c0739e0"/>
+  <project path="external/freetype" name="platform/external/freetype" revision="aeb407daf3711a10a27f3bc2223c5eb05158076e"/>
+  <project path="external/giflib" name="platform/external/giflib" revision="b2597268aef084202a8c349d1cc072c03c6e22eb"/>
+  <project path="external/gtest" name="platform/external/gtest" remote="aosp" revision="344e5f3db17615cc853073a02968a603efd39109"/>
+  <project path="external/harfbuzz" name="platform/external/harfbuzz" revision="bae491c03a00757d83ede8d855b7d85d246bde3d"/>
+  <project path="external/icu4c" name="platform/external/icu4c" revision="0fa67b93b831c6636ca18b152a1b1b14cc99b034"/>
+  <project path="external/iptables" name="platform/external/iptables" revision="3b2deb17f065c5664bb25e1a28489e5792eb63ff"/>
+  <project path="external/jhead" name="platform/external/jhead" revision="754078052c687f6721536009c816644c73e4f145"/>
+  <project path="external/jpeg" name="platform/external/jpeg" revision="d4fad7f50f79626455d88523207e05b868819cd8"/>
+  <project path="external/libgsm" name="platform/external/libgsm" revision="5e4516958690b9a1b2c98f88eeecba3edd2dbda4"/>
+  <project path="external/liblzf" name="platform/external/liblzf" revision="6946aa575b0949d045722794850896099d937cbb"/>
+  <project path="external/libnfc-nxp" name="platform/external/libnfc-nxp" revision="533c14450e6239cce8acb74f4e4dea2c89f8f219"/>
+  <project path="external/libnl-headers" name="platform/external/libnl-headers" revision="6ccf7349d61f73ac26a0675d735d903ab919c658"/>
+  <project path="external/libphonenumber" name="platform/external/libphonenumber" revision="d470984844c388d6766c3de6ac64e93e00480fc9"/>
+  <project path="external/libpng" name="platform/external/libpng" revision="84d92c718ab9f48faec0f640747c4b6f7a995607"/>
+  <project path="external/libvpx" name="platform/external/libvpx" revision="3a40da0d96da5c520e7707aa14f48a80956e20d7"/>
+  <project path="external/mksh" name="platform/external/mksh" revision="5155f1c7438ef540d7b25eb70aa1639579795b07"/>
+  <project path="external/opensans" name="platform_external_opensans" remote="b2g" revision="b5b4c226ca1d71e936153cf679dda6d3d60e2354" upstream="v1.0.0"/>
+  <project path="external/openssl" name="platform/external/openssl" revision="ce96fb211b9a44bbd7fb5ef7ed0e6c1244045c2e"/>
+  <project path="external/protobuf" name="platform/external/protobuf" revision="e217977611c52bccde7f7c78e1d3c790c6357431"/>
+  <project path="external/safe-iop" name="platform/external/safe-iop" revision="07073634e2e3aa4f518e36ed5dec3aabc549d5fb"/>
+  <project path="external/screencap-gonk" name="screencap-gonk" remote="b2g" revision="e6403c71e9eca8cb943739d5a0a192deac60fc51" upstream="v1.0.0"/>
+  <project path="external/skia" name="platform/external/skia" revision="5c67a309e16bffe7013defda8f1217b3ce2420b4"/>
+  <project path="external/sonivox" name="platform/external/sonivox" revision="5f9600971859fe072f31b38a51c38157f5f9b381"/>
+  <project path="external/speex" name="platform/external/speex" revision="ebe6230a7f7c69f5a4389f2b09b7b19ef9e94f32"/>
+  <project path="external/sqlite" name="platform/external/sqlite" revision="c999ff8c12a4cf81cb9ad628f47b2720effba5e5"/>
+  <project path="external/stlport" name="platform/external/stlport" revision="a6734e0645fce81c9610de0488b729207bfa576e"/>
+  <project path="external/strace" name="platform/external/strace" revision="c9fd2e5ef7d002e12e7cf2512506c84a9414b0fd"/>
+  <project path="external/tagsoup" name="platform/external/tagsoup" revision="68c2ec9e0acdb3214b7fb91dbab8c9fab8736817"/>
+  <project path="external/tinyalsa" name="platform/external/tinyalsa" revision="495239e683a728957c890c124b239f9b7b8ef5a8"/>
+  <project path="external/tremolo" name="platform/external/tremolo" revision="25bd78d2392dbdc879ae53382cde9d019f79cf6f"/>
+  <project path="external/webp" name="platform/external/webp" revision="88fe2b83c4b9232cd08729556fd0485d6a6a92cd"/>
+  <project path="external/webrtc" name="platform/external/webrtc" revision="4b6dc1ec58105d17dc8c2f550124cc0621dc93b7"/>
+  <project path="external/wpa_supplicant" name="platform/external/wpa_supplicant" revision="a01d37870bbf9892d43e792e5de0683ca41c5497"/>
+  <project path="external/wpa_supplicant_8" name="platform/external/wpa_supplicant_8" revision="648b7492d15bb4efaeebdfdd8bd261563a5f6227"/>
+  <project path="external/zlib" name="platform/external/zlib" revision="69e5801bd16a495e1c1666669fe827b1ddb8d56b"/>
+  <project path="external/yaffs2" name="platform/external/yaffs2" revision="6232e2d5ab34a40d710e4b05ab0ec6e3727804e7"/>
+  <project path="frameworks/base" name="platform/frameworks/base" revision="df331873c8576e0ae34ae1ee3cc258beed373535"/>
+  <project path="frameworks/opt/emoji" name="platform/frameworks/opt/emoji" revision="a95d8db002770469d72dfaf59ff37ac96db29a87"/>
+  <project path="frameworks/support" name="platform/frameworks/support" revision="bfc8e01b7b0d5ea70ce89d0409b72b7f7d540f43"/>
+  <project path="hardware/libhardware" name="platform/hardware/libhardware" revision="a9b677fce432b29ab8f61e13796f34880dc0fe0f"/>
+  <project path="hardware/libhardware_legacy" name="platform/hardware/libhardware_legacy" revision="153d0f1a27e0a157cabb6ca9d0d88248630f5695"/>
+  <project path="hardware/ril" name="platform/hardware/ril" revision="300105d1487f5238940c18792b879793826b61f4"/>
+  <project path="libcore" name="platform/libcore" revision="fc294a48d80d9e2b2ac126edf93ad316f5f6cf72"/>
+  <project path="ndk" name="platform/ndk" revision="2d77f5a05f60029c981f299b222cfe28db18ccf7"/>
+  <project path="prebuilt" name="platform/prebuilt" revision="0e104261b6d33f87e9f86ff4249bcc0306ab278b"/>
+  <project path="system/bluetooth" name="platform/system/bluetooth" revision="2588cd802f322650ed737dfb7a10e9ad94064e99"/>
+  <project path="system/core" name="platform/system/core" revision="c2db4ffb874783220abf967ca4ccd0e6cf1ba57f"/>
+  <project path="system/extras" name="platform/system/extras" revision="fa351ab265957fa8815df3c4ca1f3c105f253e8b"/>
+  <project path="system/media" name="platform/system/media" revision="a8eea50f80327f15cb04bbdfee2d1cfcc4c3ce4a"/>
+  <project path="system/netd" name="platform/system/netd" revision="3c903b555975fa59d6688a0a6417ac7512c202e7"/>
+  <project path="system/vold" name="platform/system/vold" revision="3ad9072a5d6f6bda32123b367545649364e3c11d"/>
 
   <!-- Nexus S specific things -->
-  <project path="device/samsung/crespo" name="android-device-crespo" remote="b2g" revision="master" />
-  <project path="hardware/broadcom/wlan" name="platform/hardware/broadcom/wlan" />
+  <project path="device/samsung/crespo" name="android-device-crespo" remote="b2g" revision="5c539db3b799c2faa8966340ed2fe9ea8c52ec04" upstream="v1.0.0"/>
+  <project path="hardware/broadcom/wlan" name="platform/hardware/broadcom/wlan" revision="07ef2f509a362cc6a5825d0d19143dc4bd2474e0"/>
 
 </manifest>

--- a/optimus-l5.xml
+++ b/optimus-l5.xml
@@ -1,115 +1,107 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="caf"
-          fetch="git://codeaurora.org/" />
-  <remote  name="linaro"
-           fetch="git://android.git.linaro.org/" />
-  <remote name="mozillaorg"
-           fetch="https://git.mozilla.org/releases" />
-  <default revision="ics_chocolate"
-           remote="caf"
-           sync-j="4" />
+  <remote name="aosp" fetch="https://android.googlesource.com/"/>
+  <remote name="b2g" fetch="git://github.com/mozilla-b2g/"/>
+  <remote name="mozilla" fetch="git://github.com/mozilla/"/>
+  <remote name="caf" fetch="git://codeaurora.org/"/>
+  <remote name="linaro" fetch="git://android.git.linaro.org/"/>
+  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases"/>
+  <default revision="ics_chocolate" remote="caf" sync-j="4"/>
 
   <!-- Gonk specific things and forks -->
-  <project path="build" name="platform_build" remote="b2g" revision="master">
-    <copyfile src="core/root.mk" dest="Makefile" />
+  <project path="build" name="platform_build" remote="b2g" revision="43434d6cdbf702e6197e0791f19406860284edf6" upstream="v1.0.0">
+    <copyfile src="core/root.mk" dest="Makefile"/>
   </project>
-  <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="gaia.git" remote="mozillaorg" revision="v1.0.0" />
-  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="v1.0.0" />
-  <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
-  <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
-  <project path="external/moztt" name="moztt" remote="b2g" revision="master" />
+  <project path="dalvik" name="fake-dalvik" remote="b2g" revision="ca1f327d5acc198bb4be62fa51db2c039032c9ce" upstream="v1.0.0"/>
+  <project path="gaia" name="gaia.git" remote="mozillaorg" revision="v1.0.0"/>
+  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="v1.0.0"/>
+  <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="f46dac73e6256c25763764d5fa26ac1bdf1417ba" upstream="v1.0.0"/>
+  <project path="rilproxy" name="rilproxy" remote="b2g" revision="f634b3d50effdd42828cc757c01fdbf74e562a36" upstream="v1.0.0"/>
+  <project path="external/moztt" name="moztt" remote="b2g" revision="6ee1f8987ef36d688f97064c003ad57849dfadf2" upstream="v1.0.0"/>
 
   <!-- Stock Android things -->
-  <project path="abi/cpp" name="platform/abi/cpp" />
-  <project path="bionic" name="platform/bionic" />
-  <project path="bootable/recovery" name="platform/bootable/recovery" />
-  <project path="development" name="platform/development" />
-  <project path="device/common" name="device/common" />
-  <project path="device/sample" name="device/sample" />
-  <project path="external/apache-http" name="platform/external/apache-http" />
-  <project path="external/bluetooth/bluez" name="platform/external/bluetooth/bluez" />
-  <project path="external/bluetooth/glib" name="platform/external/bluetooth/glib" />
-  <project path="external/bluetooth/hcidump" name="platform/external/bluetooth/hcidump" />
-  <project path="external/bsdiff" name="platform/external/bsdiff" />
-  <project path="external/bzip2" name="platform/external/bzip2" />
-  <project path="external/dbus" name="platform/external/dbus" />
-  <project path="external/dhcpcd" name="platform/external/dhcpcd" />
-  <project path="external/dnsmasq" name="platform/external/dnsmasq" />
-  <project path="external/expat" name="platform/external/expat" />
-  <project path="external/fdlibm" name="platform/external/fdlibm" />
-  <project path="external/flac" name="platform/external/flac" />
-  <project path="external/freetype" name="platform/external/freetype" />
-  <project path="external/giflib" name="platform/external/giflib" />
-  <project path="external/gtest" name="platform/external/gtest" remote="linaro" revision="master" />
-  <project path="external/harfbuzz" name="platform/external/harfbuzz" />
-  <project path="external/icu4c" name="platform/external/icu4c" />
-  <project path="external/iptables" name="platform/external/iptables" />
-  <project path="external/jhead" name="platform/external/jhead" />
-  <project path="external/jpeg" name="platform/external/jpeg" />
-  <project path="external/libgsm" name="platform/external/libgsm" />
-  <project path="external/liblzf" name="platform/external/liblzf" />
-  <project path="external/libnfc-nxp" name="platform/external/libnfc-nxp" />
-  <project path="external/libnl-headers" name="platform/external/libnl-headers" />
-  <project path="external/libphonenumber" name="platform/external/libphonenumber" />
-  <project path="external/libpng" name="platform/external/libpng" />
-  <project path="external/libvpx" name="platform/external/libvpx" />
-  <project path="external/llvm" name="platform/external/llvm" />
-  <project path="external/mksh" name="platform/external/mksh" />
-  <project path="external/opensans" name="platform_external_opensans" remote="b2g" revision="master" />
-  <project path="external/openssl" name="platform/external/openssl" />
-  <project path="external/protobuf" name="platform/external/protobuf" />
-  <project path="external/safe-iop" name="platform/external/safe-iop" />
-  <project path="external/screencap-gonk" name="screencap-gonk" remote="b2g" revision="master" />
-  <project path="external/skia" name="platform/external/skia" />
-  <project path="external/sonivox" name="platform/external/sonivox" />
-  <project path="external/speex" name="platform/external/speex" />
+  <project path="abi/cpp" name="platform/abi/cpp" revision="6426040f1be4a844082c9769171ce7f5341a5528"/>
+  <project path="bionic" name="platform/bionic" revision="830d278ffdf54734ae226d0f7d7ddf855cd05e71"/>
+  <project path="bootable/recovery" name="platform/bootable/recovery" revision="6e775e442bbb3a05605ef791c0e2ef3cfb4d0b9c"/>
+  <project path="development" name="platform/development" revision="26fe3c8ce939881145fde1c3d02c8d9e0341df24"/>
+  <project path="device/common" name="device/common" revision="7c65ea240157763b8ded6154a17d3c033167afb7"/>
+  <project path="device/sample" name="device/sample" revision="5c65b46f3f65e204e9d194004d12be3e01fbf183"/>
+  <project path="external/apache-http" name="platform/external/apache-http" revision="6c9d8c58d3ed710f87c26820d903bb8aad81754f"/>
+  <project path="external/bluetooth/bluez" name="platform/external/bluetooth/bluez" revision="64ae20474f5530d1b70c8f45f44a88baa20d7eb8"/>
+  <project path="external/bluetooth/glib" name="platform/external/bluetooth/glib" revision="c6b49241cc1a8950723a5f74f8f4b4f4c3fa970e"/>
+  <project path="external/bluetooth/hcidump" name="platform/external/bluetooth/hcidump" revision="02b1eb24fbb3d0135a81edb4a2175b1397308d7d"/>
+  <project path="external/bsdiff" name="platform/external/bsdiff" revision="81872540236d9bb15cccf963d05b9de48baa5375"/>
+  <project path="external/bzip2" name="platform/external/bzip2" revision="048dacdca43eed1534689ececcf2781c63e1e4ba"/>
+  <project path="external/dbus" name="platform/external/dbus" revision="00575b6b2197509c1a0ca5440323853be012e348"/>
+  <project path="external/dhcpcd" name="platform/external/dhcpcd" revision="145e318beda85c4530f84d4c53885c421e80784e"/>
+  <project path="external/dnsmasq" name="platform/external/dnsmasq" revision="f621afad94df46204c25fc2593a19d704d2637f5"/>
+  <project path="external/expat" name="platform/external/expat" revision="6df134250feab71edb5915ecaa6268210bca76c5"/>
+  <project path="external/fdlibm" name="platform/external/fdlibm" revision="988ffeb12a6e044ae3504838ef1fee3fe0716934"/>
+  <project path="external/flac" name="platform/external/flac" revision="5893fbe890f5dab8e4146d2baa4bd2691c0739e0"/>
+  <project path="external/freetype" name="platform/external/freetype" revision="aeb407daf3711a10a27f3bc2223c5eb05158076e"/>
+  <project path="external/giflib" name="platform/external/giflib" revision="b2597268aef084202a8c349d1cc072c03c6e22eb"/>
+  <project path="external/gtest" name="platform/external/gtest" remote="linaro" revision="344e5f3db17615cc853073a02968a603efd39109"/>
+  <project path="external/harfbuzz" name="platform/external/harfbuzz" revision="116610d63a859521dacf00fb6818ee9ab2e666f6"/>
+  <project path="external/icu4c" name="platform/external/icu4c" revision="0fa67b93b831c6636ca18b152a1b1b14cc99b034"/>
+  <project path="external/iptables" name="platform/external/iptables" revision="3b2deb17f065c5664bb25e1a28489e5792eb63ff"/>
+  <project path="external/jhead" name="platform/external/jhead" revision="754078052c687f6721536009c816644c73e4f145"/>
+  <project path="external/jpeg" name="platform/external/jpeg" revision="a62e464d672a4623233180e4023034bf825f066e"/>
+  <project path="external/libgsm" name="platform/external/libgsm" revision="5e4516958690b9a1b2c98f88eeecba3edd2dbda4"/>
+  <project path="external/liblzf" name="platform/external/liblzf" revision="6946aa575b0949d045722794850896099d937cbb"/>
+  <project path="external/libnfc-nxp" name="platform/external/libnfc-nxp" revision="3a912b065a31a72c63ad56ac224cfeaa933423b6"/>
+  <project path="external/libnl-headers" name="platform/external/libnl-headers" revision="6ccf7349d61f73ac26a0675d735d903ab919c658"/>
+  <project path="external/libphonenumber" name="platform/external/libphonenumber" revision="8d22c9a05eda1935c6dc27d188158e6ee38dc016"/>
+  <project path="external/libpng" name="platform/external/libpng" revision="18c03139328d77cb4cd95e8b3c857f1889a3a1c9"/>
+  <project path="external/libvpx" name="platform/external/libvpx" revision="c2c5125e0d86cff9bc8176232509556352245de1"/>
+  <project path="external/llvm" name="platform/external/llvm" revision="bff5923831940309f7d8ddbff5826ca6ed2dc050"/>
+  <project path="external/mksh" name="platform/external/mksh" revision="ec646e8f5e7dac9a77d1de549c6ed92c04d0cd4b"/>
+  <project path="external/opensans" name="platform_external_opensans" remote="b2g" revision="b5b4c226ca1d71e936153cf679dda6d3d60e2354" upstream="v1.0.0"/>
+  <project path="external/openssl" name="platform/external/openssl" revision="e1d98e84677124851249b153dca389b8f0ed46ab"/>
+  <project path="external/protobuf" name="platform/external/protobuf" revision="e217977611c52bccde7f7c78e1d3c790c6357431"/>
+  <project path="external/safe-iop" name="platform/external/safe-iop" revision="07073634e2e3aa4f518e36ed5dec3aabc549d5fb"/>
+  <project path="external/screencap-gonk" name="screencap-gonk" remote="b2g" revision="e6403c71e9eca8cb943739d5a0a192deac60fc51" upstream="v1.0.0"/>
+  <project path="external/skia" name="platform/external/skia" revision="82446add4f163f183090cbd4801de62e83837565"/>
+  <project path="external/sonivox" name="platform/external/sonivox" revision="7c967779dfc61ac1f346e972de91d4bfce7dccbb"/>
+  <project path="external/speex" name="platform/external/speex" revision="ebe6230a7f7c69f5a4389f2b09b7b19ef9e94f32"/>
   <project path="external/sqlite" name="platform/external/sqlite" revision="fb30e613139b8836fdc8e81e166cf3a76e5fa17f"/>
-  <project path="external/stlport" name="platform/external/stlport" />
-  <project path="external/strace" name="platform/external/strace" />
-  <project path="external/tagsoup" name="platform/external/tagsoup" />
-  <project path="external/tinyalsa" name="platform/external/tinyalsa" />
-  <project path="external/tremolo" name="platform/external/tremolo" />
-  <project path="external/unbootimg" name="unbootimg" remote="b2g" revision="master" />
-  <project path="external/webp" name="platform/external/webp" />
-  <project path="external/webrtc" name="platform/external/webrtc" />
-  <project path="external/wpa_supplicant" name="platform/external/wpa_supplicant" />
-  <project path="external/hostap" name="platform/external/hostap" />
-  <project path="external/zlib" name="platform/external/zlib" />
-  <project path="external/yaffs2" name="platform/external/yaffs2" />
+  <project path="external/stlport" name="platform/external/stlport" revision="a6734e0645fce81c9610de0488b729207bfa576e"/>
+  <project path="external/strace" name="platform/external/strace" revision="c9fd2e5ef7d002e12e7cf2512506c84a9414b0fd"/>
+  <project path="external/tagsoup" name="platform/external/tagsoup" revision="68c2ec9e0acdb3214b7fb91dbab8c9fab8736817"/>
+  <project path="external/tinyalsa" name="platform/external/tinyalsa" revision="06cc244ee512c1352215e543615738bc8ac82814"/>
+  <project path="external/tremolo" name="platform/external/tremolo" revision="25bd78d2392dbdc879ae53382cde9d019f79cf6f"/>
+  <project path="external/unbootimg" name="unbootimg" remote="b2g" revision="9464623d92eb8668544916dc5a8f4f6337d0bc08" upstream="v1.0.0"/>
+  <project path="external/webp" name="platform/external/webp" revision="88fe2b83c4b9232cd08729556fd0485d6a6a92cd"/>
+  <project path="external/webrtc" name="platform/external/webrtc" revision="137024dc8a2e9251a471e20518a9c3ae06f81f23"/>
+  <project path="external/wpa_supplicant" name="platform/external/wpa_supplicant" revision="a01d37870bbf9892d43e792e5de0683ca41c5497"/>
+  <project path="external/hostap" name="platform/external/hostap" revision="6aea090d50cbb498f5aad64b2a9843e9ecaab08a"/>
+  <project path="external/zlib" name="platform/external/zlib" revision="1364ab6004d47fa337eb19f9cc10fc2eefce1f93"/>
+  <project path="external/yaffs2" name="platform/external/yaffs2" revision="0afa916204c664b3114429637b63af1321a0aeca"/>
   <project name="platform/frameworks/base" path="frameworks/base" revision="49aed1902b259173c8d3ca12727031c3fc464a14"/>
-  <project path="frameworks/opt/emoji" name="platform/frameworks/opt/emoji" />
-  <project path="frameworks/support" name="platform/frameworks/support" />
-  <project path="hardware/libhardware" name="platform/hardware/libhardware" />
-  <project path="hardware/libhardware_legacy" name="platform/hardware/libhardware_legacy" />
-  <project path="libcore" name="platform/libcore" />
-  <project path="ndk" name="platform/ndk" />
-  <project path="prebuilt" name="platform/prebuilt" />
-  <project path="system/bluetooth" name="platform/system/bluetooth" />
-  <project path="system/core" name="platform/system/core" />
-  <project path="system/extras" name="platform/system/extras" />
-  <project path="system/media" name="platform/system/media" />
-  <project path="system/netd" name="platform/system/netd" />
-  <project path="system/vold" name="platform/system/vold" />
+  <project path="frameworks/opt/emoji" name="platform/frameworks/opt/emoji" revision="a95d8db002770469d72dfaf59ff37ac96db29a87"/>
+  <project path="frameworks/support" name="platform/frameworks/support" revision="27208692b001981f1806f4f396434f4eac78b909"/>
+  <project path="hardware/libhardware" name="platform/hardware/libhardware" revision="36c63f5ac44fb8b5727a5f854c7352ae4dfeaf8d"/>
+  <project path="hardware/libhardware_legacy" name="platform/hardware/libhardware_legacy" revision="a9cfa327122665da3a977f1659df37494088adb6"/>
+  <project path="libcore" name="platform/libcore" revision="9d8abfe39f2472d9eabbb7591d55a6b681a17b31"/>
+  <project path="ndk" name="platform/ndk" revision="9f555971e1481854d5b4dc11b3e6af9fff4f241f"/>
+  <project path="prebuilt" name="platform/prebuilt" revision="447ea790fcc957dde59730ecc2a65ca263bdc733"/>
+  <project path="system/bluetooth" name="platform/system/bluetooth" revision="6b0e567e1442c23977c1bc557611bd63bf2c2d01"/>
+  <project path="system/core" name="platform/system/core" revision="3272301962b99b53b74a2ff1ca2ea2729e976991"/>
+  <project path="system/extras" name="platform/system/extras" revision="01db6c1254e1407740a543f24317fc540fc4c049"/>
+  <project path="system/media" name="platform/system/media" revision="7f71c7fd362bbd992ff2e0e80f7af5859ad116ad"/>
+  <project path="system/netd" name="platform/system/netd" revision="68637a62227cf8ba9c9aa28034b2e7747cf75cbb"/>
+  <project path="system/vold" name="platform/system/vold" revision="ff8140d29751e95aa28fac28c660859e9f624e61"/>
 
   <!-- M4 specific things -->
-  <project path="device/qcom/common" name="device/qcom/common" />
-  <project path="device/qcom/msm7627a" name="platform/vendor/qcom/msm7627a" />
-  <project path="device/lge/m4" name="android-device-m4" remote="b2g" revision="master" />
-  <project path="kernel" name="codeaurora_kernel_msm" remote="b2g" revision="master" />
-  <project path="hardware/qcom/camera" name="platform/hardware/qcom/camera" />
-  <project path="hardware/qcom/display" name="hardware_qcom_display" remote="b2g" />
-  <project path="hardware/qcom/media" name="platform/hardware/qcom/media" />
-  <project path="hardware/qcom/gps" name="platform/hardware/qcom/gps" />
-  <project path="hardware/msm7k" name="platform/hardware/msm7k" />
-  <project path="vendor/qcom/opensource/omx/mm-core" name="platform/vendor/qcom-opensource/omx/mm-core" />
-  <project path="hardware/ril" name="platform/hardware/ril" />
+  <project path="device/qcom/common" name="device/qcom/common" revision="f949ec96eab89361aa4d70c2cec9edcf9980cad3"/>
+  <project path="device/qcom/msm7627a" name="platform/vendor/qcom/msm7627a" revision="51c82b9a166f059c5fb68815e690e2debcec315e"/>
+  <project path="device/lge/m4" name="android-device-m4" remote="b2g" revision="90b62c2a4ebfd3ee8b9738da96f5e38ac97009a0" upstream="v1.0.0"/>
+  <project path="kernel" name="codeaurora_kernel_msm" remote="b2g" revision="0a01247e4b0880f93424b27251cd3a1f6b19dbb2" upstream="v1.0.0"/>
+  <project path="hardware/qcom/camera" name="platform/hardware/qcom/camera" revision="a723af084e0555e68dd60d84eb872e22e6e87e69"/>
+  <project path="hardware/qcom/display" name="hardware_qcom_display" remote="b2g" upstream="v1.0.0" revision="e8de07329ce2f541a6bb21c5d72684aa9d9495ec"/>
+  <project path="hardware/qcom/media" name="platform/hardware/qcom/media" revision="46a5e287fed4dae8714c0a31be161466ce23d629"/>
+  <project path="hardware/qcom/gps" name="platform/hardware/qcom/gps" revision="aaffee42d50a77ddee9dfa041d3d328c47482285"/>
+  <project path="hardware/msm7k" name="platform/hardware/msm7k" revision="736877ca3e6d93b70e536a44d9bc759bd6d8ed82"/>
+  <project path="vendor/qcom/opensource/omx/mm-core" name="platform/vendor/qcom-opensource/omx/mm-core" revision="3905a0b8fff94ed12a1149dc72875d15a6501c7a"/>
+  <project path="hardware/ril" name="platform/hardware/ril" revision="cb1d62f78985b3611adf062d5b9cb078a4e0fb3f"/>
 </manifest>

--- a/otoro.xml
+++ b/otoro.xml
@@ -1,118 +1,110 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="https://git.mozilla.org/b2g" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="caf"
-          fetch="git://codeaurora.org/" />
-  <remote  name="linaro"
-           fetch="git://android.git.linaro.org/" />
-  <remote name="mozillaorg"
-           fetch="https://git.mozilla.org/releases" />
-  <default revision="ics_chocolate_rb4.2"
-           remote="caf"
-           sync-j="4" />
+  <remote name="aosp" fetch="https://android.googlesource.com/"/>
+  <remote name="b2g" fetch="https://git.mozilla.org/b2g"/>
+  <remote name="mozilla" fetch="git://github.com/mozilla/"/>
+  <remote name="caf" fetch="git://codeaurora.org/"/>
+  <remote name="linaro" fetch="git://android.git.linaro.org/"/>
+  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases"/>
+  <default revision="ics_chocolate_rb4.2" remote="caf" sync-j="4"/>
 
   <!-- Gonk specific things and forks -->
-  <project path="build" name="platform_build" remote="b2g" revision="master">
-    <copyfile src="core/root.mk" dest="Makefile" />
+  <project path="build" name="platform_build" remote="b2g" revision="43434d6cdbf702e6197e0791f19406860284edf6" upstream="v1.0.0">
+    <copyfile src="core/root.mk" dest="Makefile"/>
   </project>
-  <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="gaia.git" remote="mozillaorg" revision="v1.0.0" />
-  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="v1.0.0" />
-  <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
-  <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
-  <project path="librecovery" name="librecovery" remote="b2g" revision="master" />
-  <project path="external/moztt" name="moztt" remote="b2g" revision="master" />
+  <project path="dalvik" name="fake-dalvik" remote="b2g" revision="ca1f327d5acc198bb4be62fa51db2c039032c9ce" upstream="v1.0.0"/>
+  <project path="gaia" name="gaia.git" remote="mozillaorg" revision="v1.0.0"/>
+  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="v1.0.0"/>
+  <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="f46dac73e6256c25763764d5fa26ac1bdf1417ba" upstream="v1.0.0"/>
+  <project path="rilproxy" name="rilproxy" remote="b2g" revision="f634b3d50effdd42828cc757c01fdbf74e562a36" upstream="v1.0.0"/>
+  <project path="librecovery" name="librecovery" remote="b2g" revision="601fc18b28c9d7cf6954b281ddd3b705c74a9215" upstream="v1.0.0"/>
+  <project path="external/moztt" name="moztt" remote="b2g" revision="6ee1f8987ef36d688f97064c003ad57849dfadf2" upstream="v1.0.0"/>
 
   <!-- Stock Android things -->
-  <project path="abi/cpp" name="platform/abi/cpp" />
-  <project path="bionic" name="platform/bionic" />
-  <project path="bootable/recovery" name="platform/bootable/recovery" />
-  <project path="development" name="platform/development" />
-  <project path="device/common" name="device/common" />
-  <project path="device/sample" name="device/sample" />
-  <project path="external/apache-http" name="platform/external/apache-http" />
-  <project path="external/bluetooth/bluez" name="platform/external/bluetooth/bluez" />
-  <project path="external/bluetooth/glib" name="platform/external/bluetooth/glib" />
-  <project path="external/bluetooth/hcidump" name="platform/external/bluetooth/hcidump" />
-  <project path="external/bsdiff" name="platform/external/bsdiff" />
-  <project path="external/bzip2" name="platform/external/bzip2" />
-  <project path="external/dbus" name="platform/external/dbus" />
-  <project path="external/dhcpcd" name="platform/external/dhcpcd" />
-  <project path="external/dnsmasq" name="platform/external/dnsmasq" />
-  <project path="external/e2fsprogs" name="platform/external/e2fsprogs" />
-  <project path="external/expat" name="platform/external/expat" />
-  <project path="external/fdlibm" name="platform/external/fdlibm" />
-  <project path="external/flac" name="platform/external/flac" />
-  <project path="external/freetype" name="platform/external/freetype" />
-  <project path="external/giflib" name="platform/external/giflib" />
-  <project path="external/gtest" name="platform/external/gtest" remote="linaro" revision="master" />
-  <project path="external/harfbuzz" name="platform/external/harfbuzz" />
-  <project path="external/icu4c" name="platform/external/icu4c" />
-  <project path="external/iptables" name="platform/external/iptables" />
-  <project path="external/jhead" name="platform/external/jhead" />
-  <project path="external/jpeg" name="platform/external/jpeg" />
-  <project path="external/libgsm" name="platform/external/libgsm" />
-  <project path="external/liblzf" name="platform/external/liblzf" />
-  <project path="external/libnfc-nxp" name="platform/external/libnfc-nxp" />
-  <project path="external/libnl-headers" name="platform/external/libnl-headers" />
-  <project path="external/libphonenumber" name="platform/external/libphonenumber" />
-  <project path="external/libpng" name="platform/external/libpng" />
-  <project path="external/libvpx" name="platform/external/libvpx" />
-  <project path="external/llvm" name="platform/external/llvm" />
-  <project path="external/mksh" name="platform/external/mksh" />
-  <project path="external/opensans" name="platform_external_opensans" remote="b2g" revision="master" />
-  <project path="external/openssl" name="platform/external/openssl" />
-  <project path="external/protobuf" name="platform/external/protobuf" />
-  <project path="external/safe-iop" name="platform/external/safe-iop" />
-  <project path="external/screencap-gonk" name="screencap-gonk" remote="b2g" revision="master" />
-  <project path="external/skia" name="platform/external/skia" />
-  <project path="external/sonivox" name="platform/external/sonivox" />
-  <project path="external/speex" name="platform/external/speex" />
+  <project path="abi/cpp" name="platform/abi/cpp" revision="6426040f1be4a844082c9769171ce7f5341a5528"/>
+  <project path="bionic" name="platform/bionic" revision="cd5dfce80bc3f0139a56b58aca633202ccaee7f8"/>
+  <project path="bootable/recovery" name="platform/bootable/recovery" revision="e0a9ac010df3afaa47ba107192c05ac8b5516435"/>
+  <project path="development" name="platform/development" revision="a384622f5fcb1d2bebb9102591ff7ae91fe8ed2d"/>
+  <project path="device/common" name="device/common" revision="7c65ea240157763b8ded6154a17d3c033167afb7"/>
+  <project path="device/sample" name="device/sample" revision="c328f3d4409db801628861baa8d279fb8855892f"/>
+  <project path="external/apache-http" name="platform/external/apache-http" revision="6c9d8c58d3ed710f87c26820d903bb8aad81754f"/>
+  <project path="external/bluetooth/bluez" name="platform/external/bluetooth/bluez" revision="1023c91c66e9c3bd1132480051993bf7827770f6"/>
+  <project path="external/bluetooth/glib" name="platform/external/bluetooth/glib" revision="c6b49241cc1a8950723a5f74f8f4b4f4c3fa970e"/>
+  <project path="external/bluetooth/hcidump" name="platform/external/bluetooth/hcidump" revision="02b1eb24fbb3d0135a81edb4a2175b1397308d7d"/>
+  <project path="external/bsdiff" name="platform/external/bsdiff" revision="81872540236d9bb15cccf963d05b9de48baa5375"/>
+  <project path="external/bzip2" name="platform/external/bzip2" revision="048dacdca43eed1534689ececcf2781c63e1e4ba"/>
+  <project path="external/dbus" name="platform/external/dbus" revision="c7517b6195dc6926728352113e6cc335da3f9c9e"/>
+  <project path="external/dhcpcd" name="platform/external/dhcpcd" revision="1e00fb67022d0921af0fead263f81762781b9ffa"/>
+  <project path="external/dnsmasq" name="platform/external/dnsmasq" revision="f621afad94df46204c25fc2593a19d704d2637f5"/>
+  <project path="external/e2fsprogs" name="platform/external/e2fsprogs" revision="d5f550bb2f556c5d287f7c8d2b77223654bcec37"/>
+  <project path="external/expat" name="platform/external/expat" revision="6df134250feab71edb5915ecaa6268210bca76c5"/>
+  <project path="external/fdlibm" name="platform/external/fdlibm" revision="988ffeb12a6e044ae3504838ef1fee3fe0716934"/>
+  <project path="external/flac" name="platform/external/flac" revision="5893fbe890f5dab8e4146d2baa4bd2691c0739e0"/>
+  <project path="external/freetype" name="platform/external/freetype" revision="aeb407daf3711a10a27f3bc2223c5eb05158076e"/>
+  <project path="external/giflib" name="platform/external/giflib" revision="b2597268aef084202a8c349d1cc072c03c6e22eb"/>
+  <project path="external/gtest" name="platform/external/gtest" remote="linaro" revision="344e5f3db17615cc853073a02968a603efd39109"/>
+  <project path="external/harfbuzz" name="platform/external/harfbuzz" revision="116610d63a859521dacf00fb6818ee9ab2e666f6"/>
+  <project path="external/icu4c" name="platform/external/icu4c" revision="0fa67b93b831c6636ca18b152a1b1b14cc99b034"/>
+  <project path="external/iptables" name="platform/external/iptables" revision="3b2deb17f065c5664bb25e1a28489e5792eb63ff"/>
+  <project path="external/jhead" name="platform/external/jhead" revision="754078052c687f6721536009c816644c73e4f145"/>
+  <project path="external/jpeg" name="platform/external/jpeg" revision="a62e464d672a4623233180e4023034bf825f066e"/>
+  <project path="external/libgsm" name="platform/external/libgsm" revision="5e4516958690b9a1b2c98f88eeecba3edd2dbda4"/>
+  <project path="external/liblzf" name="platform/external/liblzf" revision="6946aa575b0949d045722794850896099d937cbb"/>
+  <project path="external/libnfc-nxp" name="platform/external/libnfc-nxp" revision="3a912b065a31a72c63ad56ac224cfeaa933423b6"/>
+  <project path="external/libnl-headers" name="platform/external/libnl-headers" revision="6ccf7349d61f73ac26a0675d735d903ab919c658"/>
+  <project path="external/libphonenumber" name="platform/external/libphonenumber" revision="8d22c9a05eda1935c6dc27d188158e6ee38dc016"/>
+  <project path="external/libpng" name="platform/external/libpng" revision="9c3730f0efa69f580f03463c237cd928f3196404"/>
+  <project path="external/libvpx" name="platform/external/libvpx" revision="3a40da0d96da5c520e7707aa14f48a80956e20d7"/>
+  <project path="external/llvm" name="platform/external/llvm" revision="bff5923831940309f7d8ddbff5826ca6ed2dc050"/>
+  <project path="external/mksh" name="platform/external/mksh" revision="ec646e8f5e7dac9a77d1de549c6ed92c04d0cd4b"/>
+  <project path="external/opensans" name="platform_external_opensans" remote="b2g" revision="b5b4c226ca1d71e936153cf679dda6d3d60e2354" upstream="v1.0.0"/>
+  <project path="external/openssl" name="platform/external/openssl" revision="27d333cce9a31c806b4bfa042925f045c727aecd"/>
+  <project path="external/protobuf" name="platform/external/protobuf" revision="e217977611c52bccde7f7c78e1d3c790c6357431"/>
+  <project path="external/safe-iop" name="platform/external/safe-iop" revision="07073634e2e3aa4f518e36ed5dec3aabc549d5fb"/>
+  <project path="external/screencap-gonk" name="screencap-gonk" remote="b2g" revision="e6403c71e9eca8cb943739d5a0a192deac60fc51" upstream="v1.0.0"/>
+  <project path="external/skia" name="platform/external/skia" revision="7d90c85f2c0e3b747f7c7eff8bc9253b0063b439"/>
+  <project path="external/sonivox" name="platform/external/sonivox" revision="7c967779dfc61ac1f346e972de91d4bfce7dccbb"/>
+  <project path="external/speex" name="platform/external/speex" revision="ebe6230a7f7c69f5a4389f2b09b7b19ef9e94f32"/>
   <project path="external/sqlite" name="platform/external/sqlite" revision="fb30e613139b8836fdc8e81e166cf3a76e5fa17f"/>
-  <project path="external/stlport" name="platform/external/stlport" />
-  <project path="external/strace" name="platform/external/strace" />
-  <project path="external/tagsoup" name="platform/external/tagsoup" />
-  <project path="external/tinyalsa" name="platform/external/tinyalsa" />
-  <project path="external/tremolo" name="platform/external/tremolo" />
-  <project path="external/unbootimg" name="unbootimg" remote="b2g" revision="master" />
-  <project path="external/webp" name="platform/external/webp" />
-  <project path="external/webrtc" name="platform/external/webrtc" />
-  <project path="external/wpa_supplicant" name="platform/external/wpa_supplicant" />
-  <project path="external/hostap" name="platform/external/hostap" />
-  <project path="external/zlib" name="platform/external/zlib" />
-  <project path="external/yaffs2" name="platform/external/yaffs2" />
-  <project name="platform/frameworks/base" path="frameworks/base" />
-  <project path="frameworks/opt/emoji" name="platform/frameworks/opt/emoji" />
-  <project path="frameworks/support" name="platform/frameworks/support" />
-  <project path="hardware/libhardware" name="platform/hardware/libhardware" />
-  <project path="hardware/libhardware_legacy" name="platform/hardware/libhardware_legacy" />
-  <project path="libcore" name="platform/libcore" />
-  <project path="ndk" name="platform/ndk" />
-  <project path="prebuilt" name="platform/prebuilt" />
-  <project path="system/bluetooth" name="platform/system/bluetooth" />
-  <project path="system/core" name="platform/system/core" />
-  <project path="system/extras" name="platform/system/extras" />
-  <project path="system/media" name="platform/system/media" />
-  <project path="system/netd" name="platform/system/netd" />
-  <project path="system/vold" name="platform/system/vold" />
+  <project path="external/stlport" name="platform/external/stlport" revision="a6734e0645fce81c9610de0488b729207bfa576e"/>
+  <project path="external/strace" name="platform/external/strace" revision="c9fd2e5ef7d002e12e7cf2512506c84a9414b0fd"/>
+  <project path="external/tagsoup" name="platform/external/tagsoup" revision="68c2ec9e0acdb3214b7fb91dbab8c9fab8736817"/>
+  <project path="external/tinyalsa" name="platform/external/tinyalsa" revision="06cc244ee512c1352215e543615738bc8ac82814"/>
+  <project path="external/tremolo" name="platform/external/tremolo" revision="25bd78d2392dbdc879ae53382cde9d019f79cf6f"/>
+  <project path="external/unbootimg" name="unbootimg" remote="b2g" revision="9464623d92eb8668544916dc5a8f4f6337d0bc08" upstream="v1.0.0"/>
+  <project path="external/webp" name="platform/external/webp" revision="88fe2b83c4b9232cd08729556fd0485d6a6a92cd"/>
+  <project path="external/webrtc" name="platform/external/webrtc" revision="137024dc8a2e9251a471e20518a9c3ae06f81f23"/>
+  <project path="external/wpa_supplicant" name="platform/external/wpa_supplicant" revision="a01d37870bbf9892d43e792e5de0683ca41c5497"/>
+  <project path="external/hostap" name="platform/external/hostap" revision="bf04b0faadbdeb4b7943f2e2c4c5aa59df872bb1"/>
+  <project path="external/zlib" name="platform/external/zlib" revision="f96a1d1ebfdf1cd582210fd09c23d8f59e0ae094"/>
+  <project path="external/yaffs2" name="platform/external/yaffs2" revision="0afa916204c664b3114429637b63af1321a0aeca"/>
+  <project name="platform/frameworks/base" path="frameworks/base" revision="eb2bc75803ca179353c24c364a9c8a8ce23e8b78"/>
+  <project path="frameworks/opt/emoji" name="platform/frameworks/opt/emoji" revision="a95d8db002770469d72dfaf59ff37ac96db29a87"/>
+  <project path="frameworks/support" name="platform/frameworks/support" revision="27208692b001981f1806f4f396434f4eac78b909"/>
+  <project path="hardware/libhardware" name="platform/hardware/libhardware" revision="4a619901847621f8a7305edf42dd07347a140484"/>
+  <project path="hardware/libhardware_legacy" name="platform/hardware/libhardware_legacy" revision="87b4d7afa8f854b445e2d0d95091f6f6069f2b30"/>
+  <project path="libcore" name="platform/libcore" revision="30841f9fba9ccd5c54f4f079f495994db97f283e"/>
+  <project path="ndk" name="platform/ndk" revision="9f555971e1481854d5b4dc11b3e6af9fff4f241f"/>
+  <project path="prebuilt" name="platform/prebuilt" revision="447ea790fcc957dde59730ecc2a65ca263bdc733"/>
+  <project path="system/bluetooth" name="platform/system/bluetooth" revision="7772cad4823f1f427ce1d4df84a55982386d6d18"/>
+  <project path="system/core" name="platform/system/core" revision="bf1970408676ce570b8f4dc3efa038e47552137f"/>
+  <project path="system/extras" name="platform/system/extras" revision="01db6c1254e1407740a543f24317fc540fc4c049"/>
+  <project path="system/media" name="platform/system/media" revision="7f71c7fd362bbd992ff2e0e80f7af5859ad116ad"/>
+  <project path="system/netd" name="platform/system/netd" revision="306e765248e3900041bf2737e9f57b1b5694a4ce"/>
+  <project path="system/vold" name="platform/system/vold" revision="99fff257d53cc045d1460841edca5d901dacfcf5"/>
 
   <!-- Otoro/Unagi specific things -->
-  <project path="device/qcom/common" name="device/qcom/common" />
-  <project path="device/qcom/msm7627a" name="platform/vendor/qcom/msm7627a" />
-  <project path="device/qcom/otoro" name="android-device-otoro" remote="b2g" revision="master" />
-  <project path="device/qcom/unagi" name="android-device-unagi" remote="b2g" revision="master" />
-  <project path="kernel" name="codeaurora_kernel_msm" remote="b2g" revision="master" />
-  <project path="hardware/qcom/camera" name="platform/hardware/qcom/camera" />
-  <project path="hardware/qcom/display" name="hardware_qcom_display" remote="b2g" />
-  <project path="hardware/qcom/media" name="platform/hardware/qcom/media" />
-  <project path="hardware/qcom/gps" name="platform/hardware/qcom/gps" />
-  <project path="hardware/msm7k" name="platform/hardware/msm7k" />
-  <project path="vendor/qcom/opensource/omx/mm-core" name="platform/vendor/qcom-opensource/omx/mm-core" />
+  <project path="device/qcom/common" name="device/qcom/common" revision="b9cdab8e1e1a215a8c65b8d5816f666bec7be205"/>
+  <project path="device/qcom/msm7627a" name="platform/vendor/qcom/msm7627a" revision="d920a502ba17cf4d716f8b1a615f07e796b0501a"/>
+  <project path="device/qcom/otoro" name="android-device-otoro" remote="b2g" revision="7662275433fc0b1d8b035f03185b24b7ca965ab4" upstream="v1.0.0"/>
+  <project path="device/qcom/unagi" name="android-device-unagi" remote="b2g" revision="6c014552d1b26bee611d9a9b23bd4cd014e392ee" upstream="v1.0.0"/>
+  <project path="kernel" name="codeaurora_kernel_msm" remote="b2g" revision="0a01247e4b0880f93424b27251cd3a1f6b19dbb2" upstream="v1.0.0"/>
+  <project path="hardware/qcom/camera" name="platform/hardware/qcom/camera" revision="1acf77a75e30f3fc8b1eed2057c97adf1cb1633f"/>
+  <project path="hardware/qcom/display" name="hardware_qcom_display" remote="b2g" upstream="v1.0.0" revision="6405d30f2fac7d8a1f2cb17b99fb7dd0a8bcfdac"/>
+  <project path="hardware/qcom/media" name="platform/hardware/qcom/media" revision="552c3ddb7174a01f3508782d40c4d8c845ab441a"/>
+  <project path="hardware/qcom/gps" name="platform/hardware/qcom/gps" revision="23d5707b320d7fc69f8ba3b7d84d78a1c5681708"/>
+  <project path="hardware/msm7k" name="platform/hardware/msm7k" revision="8892d46805c5639b55dd07547745c5180da861e7"/>
+  <project path="vendor/qcom/opensource/omx/mm-core" name="platform/vendor/qcom-opensource/omx/mm-core" revision="ab17ac9a074b4bb69986a8436336bdfbbaf9cd39"/>
   <project path="hardware/ril" name="platform/hardware/ril" remote="caf" revision="fe9a3f63922143b57e79ed570bab2328df8c83a5"/>
 </manifest>

--- a/pandaboard.xml
+++ b/pandaboard.xml
@@ -1,108 +1,101 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote  name="linaro"
-           fetch="git://android.git.linaro.org/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="mozillaorg" 
-      fetch="https://git.mozilla.org/releases" />
-  <default revision="refs/tags/android-4.0.4_r2.1"
-           remote="linaro"
-           sync-j="4" />
+  <remote name="aosp" fetch="https://android.googlesource.com/"/>
+  <remote name="b2g" fetch="git://github.com/mozilla-b2g/"/>
+  <remote name="linaro" fetch="git://android.git.linaro.org/"/>
+  <remote name="mozilla" fetch="git://github.com/mozilla/"/>
+  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases"/>
+  <default revision="refs/tags/android-4.0.4_r2.1" remote="linaro" sync-j="4"/>
 
   <!-- Gonk specific things and forks -->
-  <project path="build" name="platform_build" remote="b2g" revision="master">
-    <copyfile src="core/root.mk" dest="Makefile" />
+  <project path="build" name="platform_build" remote="b2g" revision="43434d6cdbf702e6197e0791f19406860284edf6" upstream="v1.0.0">
+    <copyfile src="core/root.mk" dest="Makefile"/>
   </project>
-  <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="gaia.git" remote="mozillaorg" revision="v1.0.0" />
-  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="v1.0.0" />
-  <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
-  <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
-  <project path="external/moztt" name="moztt" remote="b2g" revision="master" />
+  <project path="dalvik" name="fake-dalvik" remote="b2g" revision="ca1f327d5acc198bb4be62fa51db2c039032c9ce" upstream="v1.0.0"/>
+  <project path="gaia" name="gaia.git" remote="mozillaorg" revision="v1.0.0"/>
+  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="v1.0.0"/>
+  <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="f46dac73e6256c25763764d5fa26ac1bdf1417ba" upstream="v1.0.0"/>
+  <project path="rilproxy" name="rilproxy" remote="b2g" revision="f634b3d50effdd42828cc757c01fdbf74e562a36" upstream="v1.0.0"/>
+  <project path="external/moztt" name="moztt" remote="b2g" revision="6ee1f8987ef36d688f97064c003ad57849dfadf2" upstream="v1.0.0"/>
 
   <!-- Stock Android things -->
-  <project path="abi/cpp" name="platform/abi/cpp" />
-  <project path="bionic" name="platform/bionic" />
-  <project path="bootable/recovery" name="platform/bootable/recovery" />
-  <project path="device/common" name="device/common" />
-  <project path="device/sample" name="device/sample" />
-  <project path="external/apache-http" name="platform/external/apache-http" />
-  <project path="external/bluetooth/bluez" name="platform/external/bluetooth/bluez" />
-  <project path="external/bluetooth/glib" name="platform/external/bluetooth/glib" />
-  <project path="external/bluetooth/hcidump" name="platform/external/bluetooth/hcidump" />
-  <project path="external/bsdiff" name="platform/external/bsdiff" />
-  <project path="external/busybox" name="platform/external/busybox" remote="linaro" revision="linaro-1.20" />
-  <project path="external/bzip2" name="platform/external/bzip2" />
-  <project path="external/dbus" name="platform/external/dbus" />
-  <project path="external/dhcpcd" name="platform/external/dhcpcd" />
-  <project path="external/dnsmasq" name="platform/external/dnsmasq" />
-  <project path="external/expat" name="platform/external/expat" />
-  <project path="external/fdlibm" name="platform/external/fdlibm" />
-  <project path="external/flac" name="platform/external/flac" />
-  <project path="external/freetype" name="platform/external/freetype" />
-  <project path="external/giflib" name="platform/external/giflib" />
-  <project path="external/gtest" name="platform/external/gtest" remote="linaro" revision="master" />
-  <project path="external/harfbuzz" name="platform/external/harfbuzz" />
-  <project path="external/icu4c" name="platform/external/icu4c" />
-  <project path="external/iptables" name="platform/external/iptables" />
-  <project path="external/jhead" name="platform/external/jhead" />
-  <project path="external/jpeg" name="platform/external/jpeg" />
-  <project path="external/libgsm" name="platform/external/libgsm" />
-  <project path="external/liblzf" name="platform/external/liblzf" />
-  <project path="external/libnfc-nxp" name="platform/external/libnfc-nxp" />
-  <project path="external/libnl-headers" name="platform/external/libnl-headers" />
-  <project path="external/libphonenumber" name="platform/external/libphonenumber" />
-  <project path="external/libpng" name="platform/external/libpng" />
-  <project path="external/libvpx" name="platform/external/libvpx" />
-  <project path="external/mksh" name="platform/external/mksh" />
-  <project path="external/opensans" name="platform_external_opensans" remote="b2g" revision="master" />
-  <project path="external/openssl" name="platform/external/openssl" />
-  <project path="external/protobuf" name="platform/external/protobuf" />
-  <project path="external/safe-iop" name="platform/external/safe-iop" />
-  <project path="external/screencap-gonk" name="screencap-gonk" remote="b2g" revision="master" />
-  <project path="external/skia" name="platform/external/skia" />
-  <project path="external/sonivox" name="platform/external/sonivox" />
-  <project path="external/speex" name="platform/external/speex" />
-  <project path="external/sqlite" name="platform/external/sqlite" />
-  <project path="external/stlport" name="platform/external/stlport" />
-  <project path="external/strace" name="platform/external/strace" />
-  <project path="external/tagsoup" name="platform/external/tagsoup" />
-  <project path="external/tinyalsa" name="platform/external/tinyalsa" />
-  <project path="external/tremolo" name="platform/external/tremolo" />
-  <project path="external/webp" name="platform/external/webp" />
-  <project path="external/webrtc" name="platform/external/webrtc" />
-  <project path="external/wpa_supplicant" name="platform/external/wpa_supplicant" />
-  <project path="external/wpa_supplicant_8" name="platform/external/wpa_supplicant_8" revision="6dd24fc3792d71edccef9b09140f9a44b063a553" />
-  <project path="external/zlib" name="platform/external/zlib" />
-  <project path="external/yaffs2" name="platform/external/yaffs2" />
-  <project path="frameworks/base" name="platform/frameworks/base" />
-  <project path="frameworks/opt/emoji" name="platform/frameworks/opt/emoji" />
-  <project path="frameworks/support" name="platform/frameworks/support" />
-  <project path="hardware/libhardware" name="platform/hardware/libhardware" />
-  <project path="hardware/libhardware_legacy" name="platform/hardware/libhardware_legacy" />
-  <project path="hardware/ril" name="platform/hardware/ril" />
-  <project path="libcore" name="platform/libcore" />
-  <project path="ndk" name="platform/ndk" />
-  <project path="prebuilt" name="platform/prebuilt" />
-  <project path="system/bluetooth" name="platform/system/bluetooth" />
-  <project path="system/core" name="platform/system/core" />
-  <project path="system/extras" name="platform/system/extras" />
-  <project path="system/media" name="platform/system/media" />
-  <project path="system/netd" name="platform/system/netd" />
-  <project path="system/vold" name="platform/system/vold" />
+  <project path="abi/cpp" name="platform/abi/cpp" revision="6426040f1be4a844082c9769171ce7f5341a5528"/>
+  <project path="bionic" name="platform/bionic" revision="3d11bf0f3f3cf848f6f1e8449bf8736d8d1c78a3"/>
+  <project path="bootable/recovery" name="platform/bootable/recovery" revision="fadc5ac81d6400ebdd041f7d4ea64021596d6b7d"/>
+  <project path="device/common" name="device/common" revision="7d4526582f88808a3194e1a3b304abb369d2745c"/>
+  <project path="device/sample" name="device/sample" revision="ef228b8b377a9663e94be4b1aeb6c2bf7a07d098"/>
+  <project path="external/apache-http" name="platform/external/apache-http" revision="6c9d8c58d3ed710f87c26820d903bb8aad81754f"/>
+  <project path="external/bluetooth/bluez" name="platform/external/bluetooth/bluez" revision="966afbd88f0bfc325bf80274ad2723c238883fa1"/>
+  <project path="external/bluetooth/glib" name="platform/external/bluetooth/glib" revision="1143b9918eab068401b604eb11c3f651f4e38b25"/>
+  <project path="external/bluetooth/hcidump" name="platform/external/bluetooth/hcidump" revision="7322661808c2006b7848e79e6bb72b37fbcf6710"/>
+  <project path="external/bsdiff" name="platform/external/bsdiff" revision="81872540236d9bb15cccf963d05b9de48baa5375"/>
+  <project path="external/busybox" name="platform/external/busybox" remote="linaro" revision="2e461c8029a50d986dfe4ab07ae5a1834b5c40f0"/>
+  <project path="external/bzip2" name="platform/external/bzip2" revision="048dacdca43eed1534689ececcf2781c63e1e4ba"/>
+  <project path="external/dbus" name="platform/external/dbus" revision="537eaff5de9aace3348436166d4cde7adc1e488e"/>
+  <project path="external/dhcpcd" name="platform/external/dhcpcd" revision="ddaa48f57b54b2862b3e6dcf18a44c9647f3baaa"/>
+  <project path="external/dnsmasq" name="platform/external/dnsmasq" revision="f621afad94df46204c25fc2593a19d704d2637f5"/>
+  <project path="external/expat" name="platform/external/expat" revision="6df134250feab71edb5915ecaa6268210bca76c5"/>
+  <project path="external/fdlibm" name="platform/external/fdlibm" revision="988ffeb12a6e044ae3504838ef1fee3fe0716934"/>
+  <project path="external/flac" name="platform/external/flac" revision="5893fbe890f5dab8e4146d2baa4bd2691c0739e0"/>
+  <project path="external/freetype" name="platform/external/freetype" revision="aeb407daf3711a10a27f3bc2223c5eb05158076e"/>
+  <project path="external/giflib" name="platform/external/giflib" revision="b2597268aef084202a8c349d1cc072c03c6e22eb"/>
+  <project path="external/gtest" name="platform/external/gtest" remote="linaro" revision="344e5f3db17615cc853073a02968a603efd39109"/>
+  <project path="external/harfbuzz" name="platform/external/harfbuzz" revision="bae491c03a00757d83ede8d855b7d85d246bde3d"/>
+  <project path="external/icu4c" name="platform/external/icu4c" revision="0fa67b93b831c6636ca18b152a1b1b14cc99b034"/>
+  <project path="external/iptables" name="platform/external/iptables" revision="3b2deb17f065c5664bb25e1a28489e5792eb63ff"/>
+  <project path="external/jhead" name="platform/external/jhead" revision="754078052c687f6721536009c816644c73e4f145"/>
+  <project path="external/jpeg" name="platform/external/jpeg" revision="d4fad7f50f79626455d88523207e05b868819cd8"/>
+  <project path="external/libgsm" name="platform/external/libgsm" revision="5e4516958690b9a1b2c98f88eeecba3edd2dbda4"/>
+  <project path="external/liblzf" name="platform/external/liblzf" revision="6946aa575b0949d045722794850896099d937cbb"/>
+  <project path="external/libnfc-nxp" name="platform/external/libnfc-nxp" revision="533c14450e6239cce8acb74f4e4dea2c89f8f219"/>
+  <project path="external/libnl-headers" name="platform/external/libnl-headers" revision="6ccf7349d61f73ac26a0675d735d903ab919c658"/>
+  <project path="external/libphonenumber" name="platform/external/libphonenumber" revision="d470984844c388d6766c3de6ac64e93e00480fc9"/>
+  <project path="external/libpng" name="platform/external/libpng" revision="84d92c718ab9f48faec0f640747c4b6f7a995607"/>
+  <project path="external/libvpx" name="platform/external/libvpx" revision="3a40da0d96da5c520e7707aa14f48a80956e20d7"/>
+  <project path="external/mksh" name="platform/external/mksh" revision="5155f1c7438ef540d7b25eb70aa1639579795b07"/>
+  <project path="external/opensans" name="platform_external_opensans" remote="b2g" revision="b5b4c226ca1d71e936153cf679dda6d3d60e2354" upstream="v1.0.0"/>
+  <project path="external/openssl" name="platform/external/openssl" revision="ce96fb211b9a44bbd7fb5ef7ed0e6c1244045c2e"/>
+  <project path="external/protobuf" name="platform/external/protobuf" revision="e217977611c52bccde7f7c78e1d3c790c6357431"/>
+  <project path="external/safe-iop" name="platform/external/safe-iop" revision="07073634e2e3aa4f518e36ed5dec3aabc549d5fb"/>
+  <project path="external/screencap-gonk" name="screencap-gonk" remote="b2g" revision="e6403c71e9eca8cb943739d5a0a192deac60fc51" upstream="v1.0.0"/>
+  <project path="external/skia" name="platform/external/skia" revision="5c67a309e16bffe7013defda8f1217b3ce2420b4"/>
+  <project path="external/sonivox" name="platform/external/sonivox" revision="5f9600971859fe072f31b38a51c38157f5f9b381"/>
+  <project path="external/speex" name="platform/external/speex" revision="ebe6230a7f7c69f5a4389f2b09b7b19ef9e94f32"/>
+  <project path="external/sqlite" name="platform/external/sqlite" revision="c999ff8c12a4cf81cb9ad628f47b2720effba5e5"/>
+  <project path="external/stlport" name="platform/external/stlport" revision="a6734e0645fce81c9610de0488b729207bfa576e"/>
+  <project path="external/strace" name="platform/external/strace" revision="c9fd2e5ef7d002e12e7cf2512506c84a9414b0fd"/>
+  <project path="external/tagsoup" name="platform/external/tagsoup" revision="68c2ec9e0acdb3214b7fb91dbab8c9fab8736817"/>
+  <project path="external/tinyalsa" name="platform/external/tinyalsa" revision="495239e683a728957c890c124b239f9b7b8ef5a8"/>
+  <project path="external/tremolo" name="platform/external/tremolo" revision="25bd78d2392dbdc879ae53382cde9d019f79cf6f"/>
+  <project path="external/webp" name="platform/external/webp" revision="88fe2b83c4b9232cd08729556fd0485d6a6a92cd"/>
+  <project path="external/webrtc" name="platform/external/webrtc" revision="4b6dc1ec58105d17dc8c2f550124cc0621dc93b7"/>
+  <project path="external/wpa_supplicant" name="platform/external/wpa_supplicant" revision="a01d37870bbf9892d43e792e5de0683ca41c5497"/>
+  <project path="external/wpa_supplicant_8" name="platform/external/wpa_supplicant_8" revision="6dd24fc3792d71edccef9b09140f9a44b063a553"/>
+  <project path="external/zlib" name="platform/external/zlib" revision="69e5801bd16a495e1c1666669fe827b1ddb8d56b"/>
+  <project path="external/yaffs2" name="platform/external/yaffs2" revision="6232e2d5ab34a40d710e4b05ab0ec6e3727804e7"/>
+  <project path="frameworks/base" name="platform/frameworks/base" revision="df331873c8576e0ae34ae1ee3cc258beed373535"/>
+  <project path="frameworks/opt/emoji" name="platform/frameworks/opt/emoji" revision="a95d8db002770469d72dfaf59ff37ac96db29a87"/>
+  <project path="frameworks/support" name="platform/frameworks/support" revision="bfc8e01b7b0d5ea70ce89d0409b72b7f7d540f43"/>
+  <project path="hardware/libhardware" name="platform/hardware/libhardware" revision="a9b677fce432b29ab8f61e13796f34880dc0fe0f"/>
+  <project path="hardware/libhardware_legacy" name="platform/hardware/libhardware_legacy" revision="153d0f1a27e0a157cabb6ca9d0d88248630f5695"/>
+  <project path="hardware/ril" name="platform/hardware/ril" revision="300105d1487f5238940c18792b879793826b61f4"/>
+  <project path="libcore" name="platform/libcore" revision="fc294a48d80d9e2b2ac126edf93ad316f5f6cf72"/>
+  <project path="ndk" name="platform/ndk" revision="2d77f5a05f60029c981f299b222cfe28db18ccf7"/>
+  <project path="prebuilt" name="platform/prebuilt" revision="0e104261b6d33f87e9f86ff4249bcc0306ab278b"/>
+  <project path="system/bluetooth" name="platform/system/bluetooth" revision="2588cd802f322650ed737dfb7a10e9ad94064e99"/>
+  <project path="system/core" name="platform/system/core" revision="c2db4ffb874783220abf967ca4ccd0e6cf1ba57f"/>
+  <project path="system/extras" name="platform/system/extras" revision="fa351ab265957fa8815df3c4ca1f3c105f253e8b"/>
+  <project path="system/media" name="platform/system/media" revision="a8eea50f80327f15cb04bbdfee2d1cfcc4c3ce4a"/>
+  <project path="system/netd" name="platform/system/netd" revision="3c903b555975fa59d6688a0a6417ac7512c202e7"/>
+  <project path="system/vold" name="platform/system/vold" revision="3ad9072a5d6f6bda32123b367545649364e3c11d"/>
 
   <!-- Pandaboard specific things -->
-  <project path="device/ti/panda" name="android-device-panda" remote="b2g" revision="master" />
-  <project path="hardware/ti/omap4xxx" name="platform/hardware/ti/omap4xxx" />
-  <project path="hardware/ti/wlan" name="platform/hardware/ti/wlan" revision="60dfeb6e4448bfed707946ebca6612980f525e69" />
-  <project path="hardware/ti/wpan" name="platform/hardware/ti/wpan" revision="3ece7d9e08052989401e008bc397dbcd2557cfd0" />
-  <project path="external/negatus" name="Negatus" remote="mozilla" revision="master" />
-  <project path="external/orangutan" name="orangutan" remote="b2g" revision="master" />
+  <project path="device/ti/panda" name="android-device-panda" remote="b2g" revision="0e9a89187970d6fa99930c8d9cb438b935c2337c" upstream="v1.0.0"/>
+  <project path="hardware/ti/omap4xxx" name="platform/hardware/ti/omap4xxx" revision="8be8e9a68c96b6cf43c08a58e7ecd7708737c599"/>
+  <project path="hardware/ti/wlan" name="platform/hardware/ti/wlan" revision="60dfeb6e4448bfed707946ebca6612980f525e69"/>
+  <project path="hardware/ti/wpan" name="platform/hardware/ti/wpan" revision="3ece7d9e08052989401e008bc397dbcd2557cfd0"/>
+  <project path="external/negatus" name="Negatus" remote="mozilla" revision="151697c638a6781e83c76d4a01fb001aabde4e79"/>
+  <project path="external/orangutan" name="orangutan" remote="b2g" revision="601280aed7d7f29f1a78496f6fa41bd79c16305c" upstream="v1.0.0"/>
 
 </manifest>


### PR DESCRIPTION
Like before, this PR sets the repositories we control to the v1.0.0 branch and the ones that we don't to the current HEAD revision of the remote.

@cgjones -- sorry for the spam, i created my remote in the repository with the wrong URL (facepalm)
