### PR TITLE
Bug 822225: Switch bionic to linaro/ics-plus-aosp on PandaBoard

### DIFF
--- a/pandaboard.xml
+++ b/pandaboard.xml
@@ -9,7 +9,7 @@
            fetch="git://android.git.linaro.org/" />
   <remote name="mozilla"
 	  fetch="git://github.com/mozilla/" />
-  <remote name="mozillaorg" 
+  <remote name="mozillaorg"
       fetch="https://git.mozilla.org/releases" />
   <default revision="refs/tags/android-4.0.4_r2.1"
            remote="linaro"
@@ -28,7 +28,7 @@
 
   <!-- Stock Android things -->
   <project path="abi/cpp" name="platform/abi/cpp" />
-  <project path="bionic" name="platform/bionic" />
+  <project path="bionic" name="platform/bionic" revision="linaro/ics-plus-aosp" />
   <project path="bootable/recovery" name="platform/bootable/recovery" />
   <project path="device/common" name="device/common" />
   <project path="device/sample" name="device/sample" />


### PR DESCRIPTION
The new bionic branch contains changes that are already present on
other B2G devices; including a fix for bug 809367, where memory was
allocated after a new process was forked but before exec got called.

Change-Id: Icd56961a3fac455a51192a1ced3db9e9ef330744
Signed-off-by: Thomas Zimmermann tdz@users.sourceforge.net
