### PR TITLE
Use aosp as the default remote (instead of linaro) for galaxy-nexus, galaxy-s2, nexus-s-4g, and nexus-s

### DIFF
--- a/galaxy-nexus.xml
+++ b/galaxy-nexus.xml
@@ -6,7 +6,7 @@
   <remote name="linaro" fetch="http://android.git.linaro.org/git-ro/"/>
   <remote name="mozilla" fetch="git://github.com/mozilla/"/>
   <remote name="mozillaorg" fetch="https://git.mozilla.org/releases"/>
-  <default revision="refs/tags/android-4.0.4_r1.2" remote="linaro" sync-j="4"/>
+  <default revision="refs/tags/android-4.0.4_r1.2" remote="aosp" sync-j="4"/>
 
   <!-- Gonk specific things and forks -->
   <project path="build" name="platform_build" remote="b2g" revision="193e0e263fd16343188f43e6ce49e6e97b30af1b" upstream="v1-train">

--- a/galaxy-nexus.xml
+++ b/galaxy-nexus.xml
@@ -3,10 +3,11 @@
 
   <remote name="aosp" fetch="https://android.googlesource.com/"/>
   <remote name="b2g" fetch="git://github.com/mozilla-b2g/"/>
+  <remote name="caf" fetch="git://codeaurora.org/"/>
   <remote name="linaro" fetch="http://android.git.linaro.org/git-ro/"/>
   <remote name="mozilla" fetch="git://github.com/mozilla/"/>
   <remote name="mozillaorg" fetch="https://git.mozilla.org/releases"/>
-  <default revision="refs/tags/android-4.0.4_r1.2" remote="aosp" sync-j="4"/>
+  <default revision="refs/tags/android-4.0.4_r1.2" remote="caf" sync-j="4"/>
 
   <!-- Gonk specific things and forks -->
   <project path="build" name="platform_build" remote="b2g" revision="193e0e263fd16343188f43e6ce49e6e97b30af1b" upstream="v1-train">

--- a/galaxy-s2.xml
+++ b/galaxy-s2.xml
@@ -6,7 +6,7 @@
   <remote name="linaro" fetch="http://android.git.linaro.org/git-ro/"/>
   <remote name="mozilla" fetch="git://github.com/mozilla/"/>
   <remote name="mozillaorg" fetch="https://git.mozilla.org/releases"/>
-  <default revision="refs/tags/android-4.0.4_r1.2" remote="linaro" sync-j="4"/>
+  <default revision="refs/tags/android-4.0.4_r1.2" remote="aosp" sync-j="4"/>
 
   <!-- Gonk specific things and forks -->
   <project path="build" name="platform_build" remote="b2g" revision="193e0e263fd16343188f43e6ce49e6e97b30af1b" upstream="v1-train">

--- a/galaxy-s2.xml
+++ b/galaxy-s2.xml
@@ -3,10 +3,11 @@
 
   <remote name="aosp" fetch="https://android.googlesource.com/"/>
   <remote name="b2g" fetch="git://github.com/mozilla-b2g/"/>
+  <remote name="caf" fetch="git://codeaurora.org/"/>
   <remote name="linaro" fetch="http://android.git.linaro.org/git-ro/"/>
   <remote name="mozilla" fetch="git://github.com/mozilla/"/>
   <remote name="mozillaorg" fetch="https://git.mozilla.org/releases"/>
-  <default revision="refs/tags/android-4.0.4_r1.2" remote="aosp" sync-j="4"/>
+  <default revision="refs/tags/android-4.0.4_r1.2" remote="caf" sync-j="4"/>
 
   <!-- Gonk specific things and forks -->
   <project path="build" name="platform_build" remote="b2g" revision="193e0e263fd16343188f43e6ce49e6e97b30af1b" upstream="v1-train">

--- a/nexus-s-4g.xml
+++ b/nexus-s-4g.xml
@@ -6,7 +6,7 @@
   <remote name="linaro" fetch="http://android.git.linaro.org/git-ro/"/>
   <remote name="mozilla" fetch="git://github.com/mozilla/"/>
   <remote name="mozillaorg" fetch="https://git.mozilla.org/releases"/>
-  <default revision="refs/tags/android-4.0.4_r1.2" remote="linaro" sync-j="4"/>
+  <default revision="refs/tags/android-4.0.4_r1.2" remote="aosp" sync-j="4"/>
 
   <!-- Gonk specific things and forks -->
   <project path="build" name="platform_build" remote="b2g" revision="193e0e263fd16343188f43e6ce49e6e97b30af1b" upstream="v1-train">

--- a/nexus-s-4g.xml
+++ b/nexus-s-4g.xml
@@ -3,10 +3,11 @@
 
   <remote name="aosp" fetch="https://android.googlesource.com/"/>
   <remote name="b2g" fetch="git://github.com/mozilla-b2g/"/>
+  <remote name="caf" fetch="git://codeaurora.org/"/>
   <remote name="linaro" fetch="http://android.git.linaro.org/git-ro/"/>
   <remote name="mozilla" fetch="git://github.com/mozilla/"/>
   <remote name="mozillaorg" fetch="https://git.mozilla.org/releases"/>
-  <default revision="refs/tags/android-4.0.4_r1.2" remote="aosp" sync-j="4"/>
+  <default revision="refs/tags/android-4.0.4_r1.2" remote="caf" sync-j="4"/>
 
   <!-- Gonk specific things and forks -->
   <project path="build" name="platform_build" remote="b2g" revision="193e0e263fd16343188f43e6ce49e6e97b30af1b" upstream="v1-train">

--- a/nexus-s.xml
+++ b/nexus-s.xml
@@ -6,7 +6,7 @@
   <remote name="linaro" fetch="http://android.git.linaro.org/git-ro/"/>
   <remote name="mozilla" fetch="git://github.com/mozilla/"/>
   <remote name="mozillaorg" fetch="https://git.mozilla.org/releases"/>
-  <default revision="refs/tags/android-4.0.4_r1.2" remote="linaro" sync-j="4"/>
+  <default revision="refs/tags/android-4.0.4_r1.2" remote="aosp" sync-j="4"/>
 
   <!-- Gonk specific things and forks -->
   <project path="build" name="platform_build" remote="b2g" revision="193e0e263fd16343188f43e6ce49e6e97b30af1b" upstream="v1-train">

--- a/nexus-s.xml
+++ b/nexus-s.xml
@@ -3,10 +3,11 @@
 
   <remote name="aosp" fetch="https://android.googlesource.com/"/>
   <remote name="b2g" fetch="git://github.com/mozilla-b2g/"/>
+  <remote name="caf" fetch="git://codeaurora.org/"/>
   <remote name="linaro" fetch="http://android.git.linaro.org/git-ro/"/>
   <remote name="mozilla" fetch="git://github.com/mozilla/"/>
   <remote name="mozillaorg" fetch="https://git.mozilla.org/releases"/>
-  <default revision="refs/tags/android-4.0.4_r1.2" remote="aosp" sync-j="4"/>
+  <default revision="refs/tags/android-4.0.4_r1.2" remote="caf" sync-j="4"/>
 
   <!-- Gonk specific things and forks -->
   <project path="build" name="platform_build" remote="b2g" revision="193e0e263fd16343188f43e6ce49e6e97b30af1b" upstream="v1-train">


### PR DESCRIPTION
The linaro remote has apparently become unreliable for running `./config.sh` in the B2G repo.  A number of the submodules at linaro would 404. After asking around in irc.mozilla.org#b2g, Fabrice (the channel op) suggested pointing to aosp instead. This allowed `./config.sh` to install all of the submodules correctly.

This PR is for the v1-train branch. If this should be in another branch let me know. There was no README for the repo, so I wasn't sure.

Thanks!
