### PR TITLE
Bug 831147 - Integrate apitrace into build

### DIFF
--- a/emulator.xml
+++ b/emulator.xml
@@ -13,6 +13,7 @@
 	  fetch="git://github.com/mozilla/" />
   <remote name="mozillaorg" 
       fetch="https://git.mozilla.org/releases" />
+  <remote name="github" fetch="git://github.com/"/>
   <default revision="refs/tags/android-4.0.4_r2.1"
            remote="caf"
            sync-j="4" />
@@ -29,6 +30,7 @@
   <project path="hardware/ril" name="platform_hardware_ril" remote="b2g" revision="master"/>
   <project path="external/qemu" name="platform_external_qemu" remote="b2g" revision="master"/>
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />
+  <project path="external/apitrace" name="apitrace/apitrace.git" remote="github" revision="master"/>
 
   <!-- Stock Android things -->
   <project path="abi/cpp" name="platform/abi/cpp" />

--- a/galaxy-nexus.xml
+++ b/galaxy-nexus.xml
@@ -11,6 +11,7 @@
 	  fetch="git://github.com/mozilla/" />
   <remote name="mozillaorg" 
       fetch="https://git.mozilla.org/releases" />
+  <remote name="github" fetch="git://github.com/"/>
   <default revision="refs/tags/android-4.0.4_r1.2"
            remote="linaro"
            sync-j="4" />
@@ -25,6 +26,7 @@
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />
+  <project path="external/apitrace" name="apitrace/apitrace.git" remote="github" revision="master"/>
 
   <!-- Stock Android things -->
   <project path="abi/cpp" name="platform/abi/cpp" />

--- a/galaxy-s2.xml
+++ b/galaxy-s2.xml
@@ -11,6 +11,7 @@
 	  fetch="git://github.com/mozilla/" />
   <remote name="mozillaorg"
       fetch="https://git.mozilla.org/releases" />
+  <remote name="github" fetch="git://github.com/"/>
   <default revision="refs/tags/android-4.0.4_r1.2"
            remote="linaro"
            sync-j="4" />
@@ -25,6 +26,7 @@
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />
+  <project path="external/apitrace" name="apitrace/apitrace.git" remote="github" revision="master"/>
 
   <!-- Stock Android things -->
   <project path="abi/cpp" name="platform/abi/cpp" />

--- a/hamachi.xml
+++ b/hamachi.xml
@@ -11,6 +11,7 @@
           fetch="git://codeaurora.org/" />
   <remote name="mozillaorg"
           fetch="https://git.mozilla.org/releases" />
+  <remote name="github" fetch="git://github.com/"/>
   <default revision="b2g/ics_strawberry_v1"
            remote="caf"
            sync-j="4" />
@@ -27,6 +28,7 @@
   <project path="librecovery" name="librecovery" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />
   <project path="patches" name="gonk-patches" remote="b2g" revision="master" />
+  <project path="external/apitrace" name="apitrace/apitrace.git" remote="github" revision="master"/>
 
   <!-- Stock Android things -->
   <project path="abi/cpp" name="platform/abi/cpp" />

--- a/keon.xml
+++ b/keon.xml
@@ -6,6 +6,7 @@
   <remote fetch="git://codeaurora.org/" name="caf"/>
   <remote fetch="git://android.git.linaro.org/" name="linaro"/>
   <remote name="QRD" fetch="git://codeaurora.org/quic/qrd-android" />
+  <remote name="github" fetch="git://github.com/"/>
   <default remote="QRD" revision="ics_master_qrd_101" sync-j="9"/>
 
   <!-- Gonk specific things and forks -->
@@ -19,6 +20,7 @@
   <project name="rilproxy" path="rilproxy" remote="b2g" revision="master"/>
   <project name="librecovery" path="librecovery" remote="b2g" revision="master"/>
   <project name="moztt" path="external/moztt" remote="b2g" revision="master"/>
+  <project path="external/apitrace" name="apitrace/apitrace.git" remote="github" revision="master"/>
 
   <!-- Stock Android things -->
   <project name="platform/abi/cpp" path="abi/cpp" remote="caf" revision="refs/tags/AU_LINUX_GECKO_ICS_STRAWBERRY.01.00.00.19.161"/>

--- a/leo.xml
+++ b/leo.xml
@@ -11,6 +11,7 @@
           fetch="git://codeaurora.org/" />
   <remote name="mozillaorg"
           fetch="https://git.mozilla.org/releases" />
+  <remote name="github" fetch="git://github.com/"/>
   <default revision="b2g/ics_strawberry"
            remote="caf"
            sync-j="4" />
@@ -26,6 +27,7 @@
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="librecovery" name="librecovery" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />
+  <project path="external/apitrace" name="apitrace/apitrace.git" remote="github" revision="master"/>
   <project path="patches" name="gonk-patches" remote="b2g" revision="master" />
 
   <!-- Stock Android things -->

--- a/nexus-s-4g.xml
+++ b/nexus-s-4g.xml
@@ -11,6 +11,7 @@
 	  fetch="git://github.com/mozilla/" />
   <remote name="mozillaorg"
       fetch="https://git.mozilla.org/releases" />
+  <remote name="github" fetch="git://github.com/"/>
   <default revision="refs/tags/android-4.0.4_r1.2"
            remote="linaro"
            sync-j="4" />
@@ -25,6 +26,7 @@
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />
+  <project path="external/apitrace" name="apitrace/apitrace.git" remote="github" revision="master"/>
 
   <!-- Stock Android things -->
   <project path="abi/cpp" name="platform/abi/cpp" />

--- a/nexus-s.xml
+++ b/nexus-s.xml
@@ -11,6 +11,7 @@
 	  fetch="git://github.com/mozilla/" />
   <remote name="mozillaorg" 
       fetch="https://git.mozilla.org/releases" />
+  <remote name="github" fetch="git://github.com/"/>
   <default revision="refs/tags/android-4.0.4_r1.2"
            remote="linaro"
            sync-j="4" />
@@ -25,6 +26,7 @@
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />
+  <project path="external/apitrace" name="apitrace/apitrace.git" remote="github" revision="master"/>
 
   <!-- Stock Android things -->
   <project path="abi/cpp" name="platform/abi/cpp" />

--- a/optimus-l5.xml
+++ b/optimus-l5.xml
@@ -13,6 +13,7 @@
            fetch="http://android.git.linaro.org/git-ro/" />
   <remote name="mozillaorg"
            fetch="https://git.mozilla.org/releases" />
+  <remote name="github" fetch="git://github.com/"/>
   <default revision="ics_chocolate"
            remote="caf"
            sync-j="4" />
@@ -27,6 +28,7 @@
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />
+  <project path="external/apitrace" name="apitrace/apitrace.git" remote="github" revision="master"/>
 
   <!-- Stock Android things -->
   <project path="abi/cpp" name="platform/abi/cpp" />

--- a/otoro.xml
+++ b/otoro.xml
@@ -13,6 +13,7 @@
           fetch="git://codeaurora.org/" />
   <remote name="mozillaorg"
            fetch="https://git.mozilla.org/releases" />
+  <remote name="github" fetch="git://github.com/"/>
   <default revision="ics_chocolate_rb4.2"
            remote="caf"
            sync-j="4" />
@@ -28,6 +29,7 @@
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="librecovery" name="librecovery" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />
+  <project path="external/apitrace" name="apitrace/apitrace.git" remote="github" revision="master"/>
 
   <!-- Stock Android things -->
   <project path="abi/cpp" name="platform/abi/cpp" />

--- a/pandaboard.xml
+++ b/pandaboard.xml
@@ -13,6 +13,7 @@
 	  fetch="git://github.com/mozilla/" />
   <remote name="mozillaorg"
       fetch="https://git.mozilla.org/releases" />
+  <remote name="github" fetch="git://github.com/"/>
   <default revision="refs/tags/android-4.0.4_r2.1"
            remote="caf"
            sync-j="4" />
@@ -27,6 +28,7 @@
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />
+  <project path="external/apitrace" name="apitrace/apitrace.git" remote="github" revision="master"/>
 
   <!-- Stock Android things -->
   <project path="abi/cpp" name="platform/abi/cpp" />

--- a/tara.xml
+++ b/tara.xml
@@ -6,6 +6,7 @@
   <remote name="linaro" fetch="git://android.git.linaro.org/"/>
   <remote name="mozillaorg" fetch="https://git.mozilla.org/releases/"/>
   <remote name="sprd" fetch="http://sprdsource.spreadtrum.com:8085/b2g/" />
+  <remote name="github" fetch="git://github.com/"/>
   <default revision="sprdroid4.0.3_vlx_3.0_b2g"
            remote="sprd"
            sync-j="4" />
@@ -21,6 +22,7 @@
   <project name="rilproxy" path="rilproxy" remote="b2g" revision="master"/>
   <project name="librecovery" path="librecovery" remote="b2g" revision="master"/>
   <project name="moztt" path="external/moztt" remote="b2g" revision="master"/>
+  <project path="external/apitrace" name="apitrace/apitrace.git" remote="github" revision="master"/>
 
   <!-- Stock Android things -->
   <project name="platform/abi/cpp" path="abi/cpp" />


### PR DESCRIPTION
Add apitrace repo to manifest files, so that it gets fetched
when the top-level ./config.sh script is run.
