### PR TITLE
Bug 869773: Add local mirror manifest.

### DIFF
--- a/mirror.xml
+++ b/mirror.xml
@@ -110,7 +110,6 @@
   <project path="system/vold" name="platform/system/vold" />
 
   <!-- Emulator specific things -->
-  <project path="development" name="android-development" remote="b2g" revision="emu-fix" />
   <project path="device/generic/goldfish" name="device/generic/goldfish" />
   <project path="prebuilts/gcc/linux-x86/host/i686-linux-glibc2.7-4.6" name="platform/prebuilts/gcc/linux-x86/host/i686-linux-glibc2.7-4.6" revision="aosp-new/master" />
   <project path="prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.7-4.6" name="platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.7-4.6" revision="aosp-new/master" />

--- a/mirror.xml
+++ b/mirror.xml
@@ -13,6 +13,7 @@
       fetch="https://git.mozilla.org/releases" />
   <remote name="github" fetch="git://github.com/"/>
   <remote fetch="git://github.com/gp-b2g/" name="gp-b2g"/>
+  <remote name="apitrace" fetch="git://github.com/apitrace/" />
   <default revision="refs/tags/android-4.0.4_r2.1"
            remote="caf"
            sync-j="4" />
@@ -29,6 +30,9 @@
   <project path="hardware/ril" name="platform_hardware_ril" remote="b2g" revision="master"/>
   <project path="external/qemu" name="platform_external_qemu" remote="b2g" revision="master"/>
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />
+  <project path="external/valgrind" name="valgrind" remote="b2g" revision="fxos" />
+  <project path="external/VEX" name="vex" remote="b2g" revision="fxos" />
+  <project path="external/apitrace" name="apitrace" remote="apitrace" revision="master" />
   <project path="patches" name="gonk-patches" remote="b2g" revision="master" />
 
   <!-- Stock Android things -->
@@ -38,7 +42,6 @@
   <project path="development" name="platform/development" />
   <project path="device/common" name="device/common" />
   <project path="device/sample" name="device/sample" />
-  <project path="external/apitrace" name="apitrace/apitrace.git" remote="github" revision="master" />
   <project path="external/apriori" name="platform_external_apriori" remote="b2g" revision="master" />
   <project path="external/bluetooth/bluez" name="platform/external/bluetooth/bluez" />
   <project path="external/bluetooth/glib" name="platform/external/bluetooth/glib" />

--- a/mirror.xml
+++ b/mirror.xml
@@ -126,7 +126,6 @@
   <project path="hardware/qcom/gps" name="platform/hardware/qcom/gps" />
   <project path="hardware/msm7k" name="platform/hardware/msm7k" />
   <project path="vendor/qcom/opensource/omx/mm-core" name="platform/vendor/qcom-opensource/omx/mm-core" />
-  <project path="hardware/ril" name="platform/hardware/ril" remote="caf" />
 
   <!-- Otoro/Unagi/Inari specific things -->
   <project path="device/qcom/otoro" name="android-device-otoro" remote="b2g" revision="master" />

--- a/mirror.xml
+++ b/mirror.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+
+  <remote  name="aosp"
+           fetch="https://android.googlesource.com/" />
+  <remote name="caf"
+          fetch="git://codeaurora.org/" />
+  <remote name="b2g"
+           fetch="git://github.com/mozilla-b2g/" />
+  <remote name="mozilla"
+	  fetch="git://github.com/mozilla/" />
+  <remote name="mozillaorg" 
+      fetch="https://git.mozilla.org/releases" />
+  <remote name="github" fetch="git://github.com/"/>
+  <remote fetch="git://github.com/gp-b2g/" name="gp-b2g"/>
+  <default revision="refs/tags/android-4.0.4_r2.1"
+           remote="caf"
+           sync-j="4" />
+
+  <!-- Gonk specific things and forks -->
+  <project path="build" name="platform_build" remote="b2g" revision="master">
+    <copyfile src="core/root.mk" dest="Makefile" />
+  </project>
+  <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
+  <project path="gaia" name="gaia.git" remote="mozillaorg" revision="master" />
+  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="master" />
+  <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
+  <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
+  <project path="hardware/ril" name="platform_hardware_ril" remote="b2g" revision="master"/>
+  <project path="external/qemu" name="platform_external_qemu" remote="b2g" revision="master"/>
+  <project path="external/moztt" name="moztt" remote="b2g" revision="master" />
+  <project path="patches" name="gonk-patches" remote="b2g" revision="master" />
+
+  <!-- Stock Android things -->
+  <project path="abi/cpp" name="platform/abi/cpp" />
+  <project path="bionic" name="platform/bionic" />
+  <project path="bootable/recovery" name="platform/bootable/recovery" />
+  <project path="development" name="platform/development" />
+  <project path="device/common" name="device/common" />
+  <project path="device/sample" name="device/sample" />
+  <project path="external/apitrace" name="apitrace/apitrace.git" remote="github" revision="master" />
+  <project path="external/apriori" name="platform_external_apriori" remote="b2g" revision="master" />
+  <project path="external/bluetooth/bluez" name="platform/external/bluetooth/bluez" />
+  <project path="external/bluetooth/glib" name="platform/external/bluetooth/glib" />
+  <project path="external/bluetooth/hcidump" name="platform/external/bluetooth/hcidump" />
+  <project path="external/bsdiff" name="platform/external/bsdiff" />
+  <project path="external/bzip2" name="platform/external/bzip2" />
+  <project path="external/dbus" name="platform/external/dbus" />
+  <project path="external/dhcpcd" name="platform/external/dhcpcd" />
+  <project path="external/dnsmasq" name="platform/external/dnsmasq" />
+  <project path="external/elfcopy" name="platform_external_elfcopy" remote="b2g" revision="master" />
+  <project path="external/elfutils" name="platform_external_elfutils" remote="b2g" revision="master" />
+  <project path="external/e2fsprogs" name="platform/external/e2fsprogs" />
+  <project path="external/expat" name="platform/external/expat" />
+  <project path="external/fdlibm" name="platform/external/fdlibm" />
+  <project path="external/flac" name="platform/external/flac" />
+  <project path="external/freetype" name="platform/external/freetype" />
+  <project path="external/giflib" name="platform/external/giflib" />
+  <project path="external/gtest" name="platform/external/gtest" revision="aosp-new/master" />
+  <project path="external/harfbuzz" name="platform/external/harfbuzz" />
+  <project path="external/icu4c" name="platform/external/icu4c" />
+  <project path="external/iptables" name="platform/external/iptables" />
+  <project path="external/jpeg" name="platform/external/jpeg" />
+  <project path="external/libgsm" name="platform/external/libgsm" />
+  <project path="external/liblzf" name="platform/external/liblzf" />
+  <project path="external/libnfc-nxp" name="platform/external/libnfc-nxp" />
+  <project path="external/libnl-headers" name="platform/external/libnl-headers" />
+  <project path="external/libpng" name="platform/external/libpng" />
+  <project path="external/libvpx" name="platform/external/libvpx" />
+  <project path="external/llvm" name="platform/external/llvm" />
+  <project path="external/mksh" name="platform/external/mksh" />
+  <project path="external/opensans" name="platform_external_opensans" remote="b2g" revision="master" />
+  <project path="external/openssl" name="platform/external/openssl" />
+  <project path="external/protobuf" name="platform/external/protobuf" />
+  <project path="external/safe-iop" name="platform/external/safe-iop" />
+  <project path="external/screencap-gonk" name="screencap-gonk" remote="b2g" revision="master" />
+  <project path="external/skia" name="platform/external/skia" />
+  <project path="external/sonivox" name="platform/external/sonivox" />
+  <project path="external/speex" name="platform/external/speex" />
+  <project path="external/sqlite" name="platform/external/sqlite" />
+  <project path="external/stlport" name="platform/external/stlport" />
+  <project path="external/strace" name="platform/external/strace" />
+  <project path="external/tagsoup" name="platform/external/tagsoup" />
+  <project path="external/tinyalsa" name="platform/external/tinyalsa" />
+  <project path="external/tremolo" name="platform/external/tremolo" />
+  <project path="external/unbootimg" name="unbootimg" remote="b2g" revision="master" />
+  <project path="external/webp" name="platform/external/webp" />
+  <project path="external/webrtc" name="platform/external/webrtc" />
+  <project path="external/wpa_supplicant" name="platform/external/wpa_supplicant" />
+  <project path="external/wpa_supplicant_8" name="platform/external/wpa_supplicant_8" />
+  <project path="external/hostap" name="platform/external/hostap" />
+  <project path="external/zlib" name="platform/external/zlib" />
+  <project path="external/yaffs2" name="platform/external/yaffs2" />
+  <project path="frameworks/base" name="platform/frameworks/base" />
+  <project path="frameworks/opt/emoji" name="platform/frameworks/opt/emoji" />
+  <project path="frameworks/support" name="platform/frameworks/support" />
+  <project path="hardware/libhardware" name="platform/hardware/libhardware" />
+  <project path="hardware/libhardware_legacy" name="platform/hardware/libhardware_legacy" />
+  <project path="libcore" name="platform/libcore" />
+  <project path="ndk" name="platform/ndk" />
+  <project path="prebuilt" name="platform/prebuilt" />
+  <project path="system/bluetooth" name="platform/system/bluetooth" />
+  <project path="system/core" name="platform/system/core" />
+  <project path="system/extras" name="platform/system/extras" />
+  <project path="system/media" name="platform/system/media" />
+  <project path="system/netd" name="platform/system/netd" />
+  <project path="system/vold" name="platform/system/vold" />
+
+  <!-- Emulator specific things -->
+  <project path="development" name="android-development" remote="b2g" revision="emu-fix" />
+  <project path="device/generic/goldfish" name="device/generic/goldfish" />
+  <project path="prebuilts/gcc/linux-x86/host/i686-linux-glibc2.7-4.6" name="platform/prebuilts/gcc/linux-x86/host/i686-linux-glibc2.7-4.6" revision="aosp-new/master" />
+  <project path="prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.7-4.6" name="platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.7-4.6" revision="aosp-new/master" />
+  <project path="prebuilts/tools" name="platform/prebuilts/tools" revision="aosp-new/master" />
+  <project path="prebuilts/qemu-kernel" name="platform/prebuilts/qemu-kernel" revision="ec4a882d411d0d4ceadc5912ab4ce6fd4df23ab7" />
+  <project path="sdk" name="platform/sdk" revision="0d8f973905a4925e00eb9e32887c192b2148b29f" />
+
+  <!-- hamachi specific things -->
+  <project path="device/qcom/common" name="device/qcom/common" />
+  <project path="device/qcom/msm7627a" name="platform/vendor/qcom/msm7627a" />
+  <project path="device/qcom/hamachi" name="android-device-hamachi" remote="b2g" revision="master" />
+  <project path="hardware/qcom/camera" name="platform/hardware/qcom/camera" />
+  <project path="hardware/qcom/media" name="platform/hardware/qcom/media" />
+  <project path="hardware/qcom/gps" name="platform/hardware/qcom/gps" />
+  <project path="hardware/msm7k" name="platform/hardware/msm7k" />
+  <project path="vendor/qcom/opensource/omx/mm-core" name="platform/vendor/qcom-opensource/omx/mm-core" />
+  <project path="hardware/ril" name="platform/hardware/ril" remote="caf" />
+
+  <!-- Otoro/Unagi/Inari specific things -->
+  <project path="device/qcom/otoro" name="android-device-otoro" remote="b2g" revision="master" />
+  <project path="device/qcom/unagi" name="android-device-unagi" remote="b2g" revision="master" />
+  <project path="device/qcom/inari" name="device-inari" remote="b2g" revision="master" />
+  <project path="kernel" name="codeaurora_kernel_msm" remote="b2g" revision="master" />
+  <project name="kernel/msm" />
+  <project path="hardware/qcom/display" name="hardware_qcom_display" remote="b2g" />
+
+  <!-- Peak specific things -->
+  <project path="device/geeksphone/peak" name="device-gp-peak" remote="gp-b2g" revision="master" />
+  <project path="external/compat-wireless" name="external_compat-wireless" remote="gp-b2g" revision="master" />
+
+  <!-- Keon specific things -->
+  <project path="device/geeksphone/keon" name="device-gp-keon" remote="b2g" revision="master" />
+
+</manifest>


### PR DESCRIPTION
The repo tool supports creating a local mirror using the init --mirror
option.  This downloads all of the repositories referenced in the manifest,
but does not check them out.  You can then reference this mirror by using
the --reference= option to repo init.

To work well the mirror needs to download as many common repositories as
possible.  This manifest represents an attempt to do this for our current
set of project manifests.  When there were conflicts I chose to use the
most commonly referenced source.

To use this manifest the config.sh script must be updated to support
creating and using mirrors.
