### PR TITLE
Bug 873639 - Nexus S v1-train builds should use the master gaia branch t...

### DIFF
--- a/nexus-s.xml
+++ b/nexus-s.xml
@@ -13,7 +13,7 @@
     <copyfile src="core/root.mk" dest="Makefile"/>
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="ca1f327d5acc198bb4be62fa51db2c039032c9ce" upstream="v1-train"/>
-  <project path="gaia" name="gaia.git" remote="mozillaorg" revision="v1-train"/>
+  <project path="gaia" name="gaia.git" remote="mozillaorg" revision="master"/>
   <project path="gecko" name="gecko.git" remote="mozillaorg" revision="gecko-18"/>
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="73bd5f975f28fb696f3e647c50ac4fe03464d582" upstream="v1-train"/>
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="f634b3d50effdd42828cc757c01fdbf74e562a36" upstream="v1-train"/>


### PR DESCRIPTION
...hat contains HiDPI support

Verified locally that this results in a working build with nicely-sized controls.
