### PR TITLE
Bug 847351 - Avoid multiplication of definitions in B2G/.repo/manifests/...

### DIFF
--- a/base_remotes.xml
+++ b/base_remotes.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+
+  <remote name="QRD" fetch="git://codeaurora.org/quic/qrd-android" />
+  <remote name="aosp" fetch="https://android.googlesource.com/" />
+  <remote name="b2g" fetch="git://github.com/mozilla-b2g/" />
+  <remote name="caf" fetch="git://codeaurora.org/" />
+  <remote name="gp-b2g" fetch="git://github.com/gp-b2g/" />
+  <remote name="linaro" fetch="git://android.git.linaro.org/" />
+  <remote name="mozilla" fetch="git://github.com/mozilla/" />
+  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases" />
+  <remote name="sprd" fetch="http://sprdsource.spreadtrum.com:8085/b2g/" />
+
+</manifest>

--- a/emulator.xml
+++ b/emulator.xml
@@ -1,18 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote name="caf"
-          fetch="git://codeaurora.org/" />
-  <remote name="b2g"
-           fetch="https://git.mozilla.org/b2g" />
-  <remote name="b2ggithub"
-           fetch="git://github.com/mozilla-b2g/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="mozillaorg" 
-      fetch="https://git.mozilla.org/releases" />
+  <include name="base_remotes.xml" />
+
   <default revision="refs/tags/android-4.0.4_r2.1"
            remote="caf"
            sync-j="4" />
@@ -38,7 +28,7 @@
   <project path="bootable/recovery" name="platform/bootable/recovery" />
   <project path="device/common" name="device/common" />
   <project path="device/sample" name="device/sample" />
-  <project path="external/apriori" name="platform_external_apriori" remote="b2ggithub" revision="master" />
+  <project path="external/apriori" name="platform_external_apriori" remote="b2g" revision="master" />
   <project path="external/bluetooth/bluez" name="platform/external/bluetooth/bluez" />
   <project path="external/bluetooth/glib" name="platform/external/bluetooth/glib" />
   <project path="external/bluetooth/hcidump" name="platform/external/bluetooth/hcidump" />
@@ -47,8 +37,8 @@
   <project path="external/dbus" name="platform/external/dbus" />
   <project path="external/dhcpcd" name="platform/external/dhcpcd" />
   <project path="external/dnsmasq" name="platform/external/dnsmasq" />
-  <project path="external/elfcopy" name="platform_external_elfcopy" remote="b2ggithub" revision="master" />
-  <project path="external/elfutils" name="platform_external_elfutils" remote="b2ggithub" revision="master" />
+  <project path="external/elfcopy" name="platform_external_elfcopy" remote="b2g" revision="master" />
+  <project path="external/elfutils" name="platform_external_elfutils" remote="b2g" revision="master" />
   <project path="external/expat" name="platform/external/expat" />
   <project path="external/fdlibm" name="platform/external/fdlibm" />
   <project path="external/flac" name="platform/external/flac" />

--- a/galaxy-nexus.xml
+++ b/galaxy-nexus.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote  name="linaro"
-           fetch="http://android.git.linaro.org/git-ro/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="mozillaorg" 
-      fetch="https://git.mozilla.org/releases" />
-  <remote name="github" fetch="git://github.com/"/>
+  <include name="base_remotes.xml" />
+
   <default revision="refs/tags/android-4.0.4_r1.2"
            remote="linaro"
            sync-j="4" />

--- a/galaxy-s2.xml
+++ b/galaxy-s2.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote  name="linaro"
-           fetch="http://android.git.linaro.org/git-ro/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="mozillaorg"
-      fetch="https://git.mozilla.org/releases" />
-  <remote name="github" fetch="git://github.com/"/>
+  <include name="base_remotes.xml" />
+
   <default revision="refs/tags/android-4.0.4_r1.2"
            remote="linaro"
            sync-j="4" />

--- a/hamachi.xml
+++ b/hamachi.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote name="aosp"
-          fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="caf"
-          fetch="git://codeaurora.org/" />
-  <remote name="mozillaorg"
-          fetch="https://git.mozilla.org/releases" />
-  <remote name="github" fetch="git://github.com/"/>
+  <include name="base_remotes.xml" />
+
   <default revision="b2g/ics_strawberry_v1"
            remote="caf"
            sync-j="4" />

--- a/keon.xml
+++ b/keon.xml
@@ -1,12 +1,8 @@
 <?xml version="1.0" ?>
 <manifest>
-  <remote fetch="git://github.com/mozilla-b2g/" name="b2g"/>
-  <remote fetch="git://github.com/gp-b2g/" name="gp-b2g"/>
-  <remote fetch="http://git.mozilla.org/" name="mozillaorg"/>
-  <remote fetch="git://codeaurora.org/" name="caf"/>
-  <remote fetch="git://android.git.linaro.org/" name="linaro"/>
-  <remote name="QRD" fetch="git://codeaurora.org/quic/qrd-android" />
-  <remote name="github" fetch="git://github.com/"/>
+
+  <include name="base_remotes.xml" />
+
   <default remote="QRD" revision="ics_master_qrd_101" sync-j="9"/>
 
   <!-- Gonk specific things and forks -->
@@ -14,8 +10,8 @@
     <copyfile dest="Makefile" src="core/root.mk"/>
   </project>
   <project name="fake-dalvik" path="dalvik" remote="b2g" revision="master"/>
-  <project name="releases/gaia.git" path="gaia" remote="mozillaorg" revision="master" />
-  <project name="releases/gecko.git" path="gecko" remote="mozillaorg" revision="master" />
+  <project name="gaia.git" path="gaia" remote="mozillaorg" revision="master" />
+  <project name="gecko.git" path="gecko" remote="mozillaorg" revision="master" />
   <project name="gonk-misc" path="gonk-misc" remote="b2g" revision="master"/>
   <project name="rilproxy" path="rilproxy" remote="b2g" revision="master"/>
   <project name="librecovery" path="librecovery" remote="b2g" revision="master"/>

--- a/leo.xml
+++ b/leo.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote name="aosp"
-          fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="caf"
-          fetch="git://codeaurora.org/" />
-  <remote name="mozillaorg"
-          fetch="https://git.mozilla.org/releases" />
-  <remote name="github" fetch="git://github.com/"/>
+  <include name="base_remotes.xml" />
+
   <default revision="b2g/ics_strawberry"
            remote="caf"
            sync-j="4" />

--- a/nexus-4.xml
+++ b/nexus-4.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" ?><manifest>
 
-  <remote fetch="https://android.googlesource.com/" name="aosp"/>
-  <remote fetch="git://github.com/mozilla-b2g/" name="b2g"/>
-  <remote fetch="git://github.com/mozilla/" name="mozilla"/>
+  <include name="base_remotes.xml" />
 
   <default remote="aosp" revision="refs/tags/android-4.2.2_r1" sync-j="4"/>
 

--- a/nexus-s-4g.xml
+++ b/nexus-s-4g.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote  name="linaro"
-           fetch="http://android.git.linaro.org/git-ro/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="mozillaorg"
-      fetch="https://git.mozilla.org/releases" />
-  <remote name="github" fetch="git://github.com/"/>
+  <include name="base_remotes.xml" />
+
   <default revision="refs/tags/android-4.0.4_r1.2"
            remote="linaro"
            sync-j="4" />

--- a/nexus-s.xml
+++ b/nexus-s.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote  name="linaro"
-           fetch="http://android.git.linaro.org/git-ro/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="mozillaorg" 
-      fetch="https://git.mozilla.org/releases" />
-  <remote name="github" fetch="git://github.com/"/>
+  <include name="base_remotes.xml" />
+
   <default revision="refs/tags/android-4.0.4_r1.2"
            remote="linaro"
            sync-j="4" />

--- a/optimus-l5.xml
+++ b/optimus-l5.xml
@@ -1,19 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="caf"
-          fetch="git://codeaurora.org/" />
-  <remote  name="linaro"
-           fetch="http://android.git.linaro.org/git-ro/" />
-  <remote name="mozillaorg"
-           fetch="https://git.mozilla.org/releases" />
-  <remote name="github" fetch="git://github.com/"/>
+  <include name="base_remotes.xml" />
+
   <default revision="ics_chocolate"
            remote="caf"
            sync-j="4" />

--- a/otoro.xml
+++ b/otoro.xml
@@ -1,18 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote name="b2gmozilla"
-          fetch="https://git.mozilla.org/b2g" />
-  <remote name="b2g"
-           fetch="git://github.com/mozilla-b2g/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="caf"
-          fetch="git://codeaurora.org/" />
-  <remote name="mozillaorg"
-           fetch="https://git.mozilla.org/releases" />
+  <include name="base_remotes.xml" />
+
   <default revision="ics_chocolate_rb4.2"
            remote="caf"
            sync-j="4" />

--- a/pandaboard.xml
+++ b/pandaboard.xml
@@ -1,18 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote  name="linaro"
-           fetch="http://android.git.linaro.org/git-ro/" />
-  <remote name="caf"
-          fetch="git://codeaurora.org/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="mozillaorg"
-      fetch="https://git.mozilla.org/releases" />
+  <include name="base_remotes.xml" />
+
   <default revision="refs/tags/android-4.0.4_r2.1"
            remote="caf"
            sync-j="4" />

--- a/peak.xml
+++ b/peak.xml
@@ -1,11 +1,8 @@
 <?xml version="1.0" ?>
 <manifest>
-  <remote fetch="git://github.com/mozilla-b2g/" name="b2g"/>
-  <remote fetch="git://github.com/gp-b2g/" name="gp-b2g"/>
-  <remote fetch="http://git.mozilla.org/" name="mozillaorg"/>
-  <remote fetch="git://codeaurora.org/" name="caf"/>
-  <remote fetch="git://android.git.linaro.org/" name="linaro"/>
-  <remote name="QRD" fetch="git://codeaurora.org/quic/qrd-android"/>
+
+  <include name="base_remotes.xml" />
+
   <default remote="QRD" revision="ics_master_qrd_101" sync-j="9"/>
 
   <!-- Gonk specific things and forks -->
@@ -14,7 +11,7 @@
   </project>
   <project name="fake-dalvik" path="dalvik" remote="b2g" revision="master"/>
   <project name="gaia" path="gaia" remote="b2g" revision="master"/>
-  <project name="releases/gecko.git" path="gecko" remote="mozillaorg" revision="master"/>
+  <project name="gecko.git" path="gecko" remote="mozillaorg" revision="master"/>
   <project name="gonk-misc" path="gonk-misc" remote="b2g" revision="master"/>
   <project name="rilproxy" path="rilproxy" remote="b2g" revision="master"/>
   <project name="librecovery" path="librecovery" remote="b2g" revision="master"/>

--- a/tara.xml
+++ b/tara.xml
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote name="b2g" fetch="https://github.com/mozilla-b2g/"/>
-  <remote name="mozilla" fetch="git://github.com/mozilla/"/>
-  <remote name="linaro" fetch="git://android.git.linaro.org/"/>
-  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases/"/>
-  <remote name="sprd" fetch="http://sprdsource.spreadtrum.com:8085/b2g/" />
-  <remote name="github" fetch="git://github.com/"/>
+  <include name="base_remotes.xml" />
+
   <default revision="sprdroid4.0.3_vlx_3.0_b2g"
            remote="sprd"
            sync-j="4" />


### PR DESCRIPTION
Move all remotes into a single file base_remotes.xml and include it
in all manifests.

See https://bugzilla.mozilla.org/show_bug.cgi?id=847351#c24 for some details on this patch.
