### PR TITLE
Changed linaro to caf

### DIFF
--- a/nexus-s.xml
+++ b/nexus-s.xml
@@ -3,10 +3,10 @@
 
   <remote name="aosp" fetch="https://android.googlesource.com/"/>
   <remote name="b2g" fetch="git://github.com/mozilla-b2g/"/>
-  <remote name="linaro" fetch="http://android.git.linaro.org/git-ro/"/>
+  <remote name="caf" fetch="git://codeaurora.org/"/>
   <remote name="mozilla" fetch="git://github.com/mozilla/"/>
   <remote name="mozillaorg" fetch="https://git.mozilla.org/releases"/>
-  <default revision="refs/tags/android-4.0.4_r1.2" remote="linaro" sync-j="4"/>
+  <default revision="refs/tags/android-4.0.4_r1.2" remote="caf" sync-j="4"/>
 
   <!-- Gonk specific things and forks -->
   <project path="build" name="platform_build" remote="b2g" revision="7cb46499e0b91ca20f6aed58d6067d7c451875b9" upstream="v1-train">


### PR DESCRIPTION
The linaro repo was failing for Nexus S. This change has us using the codeaurora.org, which works as expected.
