### PR TITLE
Bug 852200: Use Codeaurora instead of Linaro for Galaxy Nexus devices

### DIFF
--- a/galaxy-nexus.xml
+++ b/galaxy-nexus.xml
@@ -7,13 +7,14 @@
           fetch="git://github.com/mozilla-b2g/" />
   <remote  name="linaro"
            fetch="http://android.git.linaro.org/git-ro/" />
+  <remote name="caf" fetch="git://codeaurora.org/"/>
   <remote name="mozilla"
 	  fetch="git://github.com/mozilla/" />
-  <remote name="mozillaorg" 
+  <remote name="mozillaorg"
       fetch="https://git.mozilla.org/releases" />
   <remote name="apitrace" fetch="git://github.com/apitrace/" />
   <default revision="refs/tags/android-4.0.4_r1.2"
-           remote="linaro"
+           remote="caf"
            sync-j="4" />
 
   <!-- Gonk specific things and forks -->
@@ -53,7 +54,7 @@
   <project path="external/flac" name="platform/external/flac" />
   <project path="external/freetype" name="platform/external/freetype" />
   <project path="external/giflib" name="platform/external/giflib" />
-  <project path="external/gtest" name="platform/external/gtest" remote="linaro" revision="master" />
+  <project path="external/gtest" name="platform/external/gtest" remote="caf" revision="master" />
   <project path="external/harfbuzz" name="platform/external/harfbuzz" />
   <project path="external/icu4c" name="platform/external/icu4c" />
   <project path="external/iptables" name="platform/external/iptables" />


### PR DESCRIPTION
Changes the manifest for Galaxy Nexus to use codeaurora instead of Linaro, as it is a bit unstable.