### PR TITLE
Bug 917559 - Old hardware/ril preventing hamachi devices from making calls.

### DIFF
--- a/hamachi.xml
+++ b/hamachi.xml
@@ -104,5 +104,5 @@
   <project path="hardware/qcom/gps" name="platform/hardware/qcom/gps"/>
   <project path="hardware/msm7k" name="platform/hardware/msm7k"/>
   <project path="vendor/qcom/opensource/omx/mm-core" name="platform/vendor/qcom-opensource/omx/mm-core"/>
-  <project path="hardware/ril" name="platform/hardware/ril" remote="caf" revision="86ddf397767be35acc8d625ade69767189a17d61"/>
+  <project path="hardware/ril" name="platform/hardware/ril"/>
 </manifest>


### PR DESCRIPTION
Using default as a source for "hardware/ril" in hamachi manifest.
