### PR TITLE
Bug 923032 - Fix gtest breaking Galaxy Nexus B2G build.

### DIFF
--- a/galaxy-nexus.xml
+++ b/galaxy-nexus.xml
@@ -53,7 +53,7 @@
   <project path="external/flac" name="platform/external/flac" />
   <project path="external/freetype" name="platform/external/freetype" />
   <project path="external/giflib" name="platform/external/giflib" />
-  <project path="external/gtest" name="platform/external/gtest" remote="linaro" revision="master" />
+  <project path="external/gtest" name="platform/external/gtest" remote="linaro" revision="8c212ebe53bb2baab3575f03069016f1fb11e449" />
   <project path="external/harfbuzz" name="platform/external/harfbuzz" />
   <project path="external/icu4c" name="platform/external/icu4c" />
   <project path="external/iptables" name="platform/external/iptables" />


### PR DESCRIPTION
Port from this patch:
https://github.com/past/b2g-manifest/commit/5b090e3220ea9d1d2c72663f749fae1e7f56fba3
