### PR TITLE
Bug 926609 - Add missing jhead dependency.

### DIFF
--- a/galaxy-nexus.xml
+++ b/galaxy-nexus.xml
@@ -55,6 +55,7 @@
   <project path="external/harfbuzz" name="platform/external/harfbuzz" />
   <project path="external/icu4c" name="platform/external/icu4c" />
   <project path="external/iptables" name="platform/external/iptables" />
+  <project path="external/jhead" name="platform/external/jhead" />
   <project path="external/jpeg" name="platform/external/jpeg" />
   <project path="external/libgsm" name="platform/external/libgsm" />
   <project path="external/liblzf" name="platform/external/liblzf" />


### PR DESCRIPTION
Fixes B2G build for Galaxy Nexus.
