### PR TITLE
adding i2c-tools to nexus-s manifest

### DIFF
--- a/nexus-s.xml
+++ b/nexus-s.xml
@@ -8,9 +8,9 @@
   <remote  name="caf"
           fetch="git://codeaurora.org/" />
   <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
+          fetch="git://github.com/mozilla/" />
   <remote name="mozillaorg" 
-      fetch="https://git.mozilla.org/releases" />
+          fetch="https://git.mozilla.org/releases" />
   <remote name="apitrace" fetch="git://github.com/apitrace/" />
   <default revision="refs/tags/android-4.0.4_r1.2"
            remote="caf"
@@ -52,6 +52,7 @@
   <project path="external/giflib" name="platform/external/giflib" />
   <project path="external/gtest" name="platform/external/gtest" remote="aosp" revision="8c212ebe53bb2baab3575f03069016f1fb11e449" />
   <project path="external/harfbuzz" name="platform/external/harfbuzz" />
+  <project path="external/i2c-tools" name="i2c-tools" remote="b2g" revision="b2g" />
   <project path="external/icu4c" name="platform/external/icu4c" />
   <project path="external/iptables" name="platform/external/iptables" />
   <project path="external/jpeg" name="platform/external/jpeg" />


### PR DESCRIPTION
this fixes the references to the unreliable linaro mirrors and adds i2c-tools repo in the nexus-s.xml manifest.