### PR TITLE
Bug 952535 - Use Code Aurora's platform/system/core/ at b2g_ics_1.2

### DIFF
--- a/emulator.xml
+++ b/emulator.xml
@@ -97,7 +97,7 @@
   <project path="ndk" name="platform/ndk" />
   <project path="prebuilt" name="platform/prebuilt" revision="aosp-new/master" />
   <project path="system/bluetooth" name="platform/system/bluetooth" />
-  <project path="system/core" name="platform/system/core" revision="91e5551f88aea5aa64e1b4f8b4b52d7be2b28b64" />
+  <project path="system/core" name="platform/system/core" revision="b2g_ics_1.2" />
   <project path="system/extras" name="platform/system/extras" />
   <project path="system/media" name="platform/system/media" />
   <project path="system/netd" name="platform/system/netd" />

--- a/galaxy-nexus.xml
+++ b/galaxy-nexus.xml
@@ -5,6 +5,8 @@
            fetch="https://android.googlesource.com/" />
   <remote name="b2g"
           fetch="git://github.com/mozilla-b2g/" />
+  <remote name="caf"
+          fetch="git://codeaurora.org/" />
   <remote  name="linaro"
            fetch="http://android.git.linaro.org/git-ro/" />
   <remote name="mozilla"
@@ -95,7 +97,7 @@
   <project path="ndk" name="platform/ndk" />
   <project path="prebuilt" name="platform/prebuilt" />
   <project path="system/bluetooth" name="platform/system/bluetooth" />
-  <project path="system/core" name="platform/system/core" />
+  <project path="system/core" name="platform/system/core" revision="b2g_ics_1.2" />
   <project path="system/extras" name="platform/system/extras" />
   <project path="system/media" name="platform/system/media" />
   <project path="system/netd" name="platform/system/netd" />

--- a/galaxy-s2.xml
+++ b/galaxy-s2.xml
@@ -5,6 +5,8 @@
            fetch="https://android.googlesource.com/" />
   <remote name="b2g"
           fetch="git://github.com/mozilla-b2g/" />
+  <remote name="caf"
+          fetch="git://codeaurora.org/" />
   <remote  name="linaro"
            fetch="http://android.git.linaro.org/git-ro/" />
   <remote name="mozilla"
@@ -92,7 +94,7 @@
   <project path="ndk" name="platform/ndk" />
   <project path="prebuilt" name="platform/prebuilt" />
   <project path="system/bluetooth" name="platform/system/bluetooth" />
-  <project path="system/core" name="platform/system/core" />
+  <project path="system/core" name="platform/system/core" revision="b2g_ics_1.2" />
   <project path="system/extras" name="platform/system/extras" />
   <project path="system/media" name="platform/system/media" />
   <project path="system/netd" name="platform/system/netd" />

--- a/helix.xml
+++ b/helix.xml
@@ -96,7 +96,7 @@
   <project path="ndk" name="platform/ndk"/>
   <project path="prebuilt" name="platform/prebuilt"/>
   <project path="system/bluetooth" name="platform/system/bluetooth"/>
-  <project path="system/core" name="platform/system/core"/>
+  <project path="system/core" name="platform/system/core" revision="b2g_ics_1.2"/>
   <project path="system/extras" name="platform/system/extras"/>
   <project path="system/media" name="platform/system/media"/>
   <project path="system/netd" name="platform/system/netd"/>

--- a/keon.xml
+++ b/keon.xml
@@ -87,7 +87,7 @@
   <project name="platform/ndk" path="ndk" remote="caf" revision="refs/tags/AU_LINUX_GECKO_ICS_STRAWBERRY.01.00.00.19.161"/>
   <project name="platform/prebuilt" path="prebuilt"/>
   <project name="platform/system/bluetooth" path="system/bluetooth"/>
-  <project name="platform/system/core" path="system/core"/>
+  <project name="platform/system/core" path="system/core" remote="caf" revision="b2g_ics_1.2" />
   <project name="platform/system/extras" path="system/extras"/>
   <project name="platform/system/media" path="system/media"/>
   <project name="platform/system/netd" path="system/netd"/>

--- a/leo.xml
+++ b/leo.xml
@@ -98,7 +98,7 @@
   <project path="ndk" name="platform/ndk" />
   <project path="prebuilt" name="platform/prebuilt" />
   <project path="system/bluetooth" name="platform/system/bluetooth" />
-  <project path="system/core" name="platform/system/core" />
+  <project path="system/core" name="platform/system/core" revision="b2g_ics_1.2" />
   <project path="system/extras" name="platform/system/extras" />
   <project path="system/media" name="platform/system/media" />
   <project path="system/netd" name="platform/system/netd" />

--- a/nexus-s-4g.xml
+++ b/nexus-s-4g.xml
@@ -5,6 +5,8 @@
            fetch="https://android.googlesource.com/" />
   <remote name="b2g"
           fetch="git://github.com/mozilla-b2g/" />
+  <remote  name="caf"
+          fetch="git://codeaurora.org/" />
   <remote  name="linaro"
            fetch="http://android.git.linaro.org/git-ro/" />
   <remote name="mozilla"
@@ -94,7 +96,7 @@
   <project path="ndk" name="platform/ndk" />
   <project path="prebuilt" name="platform/prebuilt" />
   <project path="system/bluetooth" name="platform/system/bluetooth" />
-  <project path="system/core" name="platform/system/core" />
+  <project path="system/core" name="platform/system/core" remote="caf" revision="b2g_ics_1.2" />
   <project path="system/extras" name="platform/system/extras" />
   <project path="system/media" name="platform/system/media" />
   <project path="system/netd" name="platform/system/netd" />

--- a/nexus-s.xml
+++ b/nexus-s.xml
@@ -93,7 +93,7 @@
   <project path="ndk" name="platform/ndk" />
   <project path="prebuilt" name="platform/prebuilt" />
   <project path="system/bluetooth" name="platform/system/bluetooth" />
-  <project path="system/core" name="platform/system/core" />
+  <project path="system/core" name="platform/system/core" remote="caf" revision="b2g_ics_1.2" />
   <project path="system/extras" name="platform/system/extras" />
   <project path="system/media" name="platform/system/media" />
   <project path="system/netd" name="platform/system/netd" />

--- a/optimus-l5.xml
+++ b/optimus-l5.xml
@@ -97,7 +97,7 @@
   <project path="ndk" name="platform/ndk" />
   <project path="prebuilt" name="platform/prebuilt" />
   <project path="system/bluetooth" name="platform/system/bluetooth" />
-  <project path="system/core" name="platform/system/core" />
+  <project path="system/core" name="platform/system/core" revision="b2g_ics_1.2" />
   <project path="system/extras" name="platform/system/extras" />
   <project path="system/media" name="platform/system/media" />
   <project path="system/netd" name="platform/system/netd" />

--- a/otoro.xml
+++ b/otoro.xml
@@ -99,7 +99,7 @@
   <project path="ndk" name="platform/ndk" />
   <project path="prebuilt" name="platform/prebuilt" />
   <project path="system/bluetooth" name="platform/system/bluetooth" />
-  <project path="system/core" name="platform/system/core" />
+  <project path="system/core" name="platform/system/core" revision="b2g_ics_1.2" />
   <project path="system/extras" name="platform/system/extras" />
   <project path="system/media" name="platform/system/media" />
   <project path="system/netd" name="platform/system/netd" />

--- a/pandaboard.xml
+++ b/pandaboard.xml
@@ -98,7 +98,7 @@
   <project path="ndk" name="platform/ndk" />
   <project path="prebuilt" name="platform/prebuilt" />
   <project path="system/bluetooth" name="platform/system/bluetooth" />
-  <project path="system/core" name="platform/system/core" />
+  <project path="system/core" name="platform/system/core" revision="b2g_ics_1.2" />
   <project path="system/extras" name="platform/system/extras" />
   <project path="system/media" name="platform/system/media" />
   <project path="system/netd" name="platform/system/netd" />

--- a/peak.xml
+++ b/peak.xml
@@ -89,7 +89,7 @@
   <project name="platform/ndk" path="ndk" remote="caf" revision="refs/tags/AU_LINUX_GECKO_ICS_STRAWBERRY.01.00.00.19.161"/>
   <project name="platform/prebuilt" path="prebuilt"/>
   <project name="platform/system/bluetooth" path="system/bluetooth"/>
-  <project name="platform/system/core" path="system/core"/>
+  <project name="platform/system/core" path="system/core" remote="caf" revision="b2g_ics_1.2" />
   <project name="platform/system/extras" path="system/extras"/>
   <project name="platform/system/media" path="system/media"/>
   <project name="platform/system/netd" path="system/netd"/>

--- a/wasabi.xml
+++ b/wasabi.xml
@@ -99,7 +99,7 @@
   <project path="ndk" name="platform/ndk" />
   <project path="prebuilt" name="platform/prebuilt" />
   <project path="system/bluetooth" name="platform/system/bluetooth" />
-  <project path="system/core" name="platform/system/core" />
+  <project path="system/core" name="platform/system/core" revision="b2g_ics_1.2" />
   <project path="system/extras" name="platform/system/extras" />
   <project path="system/media" name="platform/system/media" />
   <project path="system/netd" name="platform/system/netd" />


### PR DESCRIPTION
During build of FOTA packages, an updater-script is generated. Part of
its work is to extract new files from the ZIP update file and correctly
set the permissions. Those are set at build time of this script, via the
call of a specific binary. This binary relies on the
android_filesystem_config.h header file that lives inside
platform/system/core's include/private directory. In order to provide
update packages that works, we have to add the B2G binaries in this
header. Code Aurora's b2g_ics_1.2 is an ICS part of the repository that
has the correct patches ready for B2G, like this change. We make use of
this everywhere, to be able to produce updates for all devices we can.
