### PR TITLE
Bug 956098: config.sh nexus-s fail to run sync 

### DIFF
--- a/nexus-s.xml
+++ b/nexus-s.xml
@@ -52,7 +52,7 @@
   <project path="external/giflib" name="platform/external/giflib" />
   <project path="external/gtest" name="platform/external/gtest" remote="aosp" revision="8c212ebe53bb2baab3575f03069016f1fb11e449" />
   <project path="external/harfbuzz" name="platform/external/harfbuzz" />
-  <project path="external/icu4c" name="platform/external/icu4c" />
+  <project path="external/icu4c" name="platform/external/icu4c" remote="aosp" />
   <project path="external/iptables" name="platform/external/iptables" />
   <project path="external/jpeg" name="platform/external/jpeg" />
   <project path="external/libgsm" name="platform/external/libgsm" />


### PR DESCRIPTION
Change remote to aosp for icu4c (no tag android-4.0.4_r1.2 in default repo)
