### PR TITLE
Bug 972318 - Revert platform_build to gp-b2g master for peak. r=hwine

### DIFF
--- a/peak.xml
+++ b/peak.xml
@@ -10,7 +10,7 @@
   <default remote="QRD" revision="ics_master_qrd_101" sync-j="9"/>
 
   <!-- Gonk specific things and forks -->
-  <project name="platform_build" path="build" remote="gp-b2g" revision="v1.3">
+  <project name="platform_build" path="build" remote="gp-b2g" revision="master">
     <copyfile dest="Makefile" src="core/root.mk"/>
   </project>
   <project name="fake-dalvik" path="dalvik" remote="b2g" revision="v1.3"/>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=972318
