### PR TITLE
Bug 979986 - Use HTTPS instead of GIT or HTTP for all repositories

### DIFF
--- a/base-caf-jb.xml
+++ b/base-caf-jb.xml
@@ -2,10 +2,10 @@
 <manifest>
 
   <remote fetch="https://android.googlesource.com/" name="aosp"/>
-  <remote fetch="git://github.com/mozilla-b2g/" name="b2g"/>
-  <remote fetch="git://github.com/mozilla/" name="mozilla"/>
-  <remote fetch="git://github.com/apitrace/" name="apitrace"/>
-  <remote fetch="git://codeaurora.org/" name="caf"/>
+  <remote fetch="https://github.com/mozilla-b2g/" name="b2g"/>
+  <remote fetch="https://github.com/mozilla/" name="mozilla"/>
+  <remote fetch="https://github.com/apitrace/" name="apitrace"/>
+  <remote fetch="https://git.mozilla.org/external/caf/" name="caf"/>
   <remote fetch="https://git.mozilla.org/releases" name="mozillaorg"/>
 
   <!-- B2G specific things. -->

--- a/base-jb.xml
+++ b/base-jb.xml
@@ -2,10 +2,10 @@
 <manifest>
 
   <remote fetch="https://android.googlesource.com/" name="aosp"/>
-  <remote fetch="git://github.com/mozilla-b2g/" name="b2g"/>
-  <remote fetch="git://github.com/mozilla/" name="mozilla"/>
-  <remote fetch="git://github.com/apitrace/" name="apitrace"/>
-  <remote fetch="git://codeaurora.org/" name="caf"/>
+  <remote fetch="https://github.com/mozilla-b2g/" name="b2g"/>
+  <remote fetch="https://github.com/mozilla/" name="mozilla"/>
+  <remote fetch="https://github.com/apitrace/" name="apitrace"/>
+  <remote fetch="https://git.mozilla.org/external/caf/" name="caf"/>
   <remote fetch="https://git.mozilla.org/releases" name="mozillaorg"/>
 
   <!-- B2G specific things. -->

--- a/base-kk.xml
+++ b/base-kk.xml
@@ -2,10 +2,10 @@
 <manifest>
 
   <remote fetch="https://android.googlesource.com/" name="aosp"/>
-  <remote fetch="git://github.com/mozilla-b2g/" name="b2g"/>
-  <remote fetch="git://github.com/mozilla/" name="mozilla"/>
-  <remote fetch="git://github.com/apitrace/" name="apitrace"/>
-  <remote fetch="git://codeaurora.org/" name="caf"/>
+  <remote fetch="https://github.com/mozilla-b2g/" name="b2g"/>
+  <remote fetch="https://github.com/mozilla/" name="mozilla"/>
+  <remote fetch="https://github.com/apitrace/" name="apitrace"/>
+  <remote fetch="https://git.mozilla.org/external/caf/" name="caf"/>
   <remote fetch="https://git.mozilla.org/releases" name="mozillaorg"/>
 
   <!-- B2G specific things. -->

--- a/emulator.xml
+++ b/emulator.xml
@@ -1,22 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote name="caf"
-          fetch="git://codeaurora.org/" />
-  <remote name="b2gmozilla"
-           fetch="https://git.mozilla.org/b2g" />
-  <remote name="b2g"
-           fetch="git://github.com/mozilla-b2g/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="mozillaorg" 
-      fetch="https://git.mozilla.org/releases" />
-  <remote name="apitrace" fetch="git://github.com/apitrace/" />
-  <default revision="refs/tags/android-4.0.4_r2.1"
-           remote="caf"
-           sync-j="4" />
+  <remote name="aosp" fetch="https://android.googlesource.com/" />
+  <remote name="caf" fetch="https://git.mozilla.org/external/caf/" />
+  <remote name="b2gmozilla" fetch="https://git.mozilla.org/b2g" />
+  <remote name="b2g" fetch="https://github.com/mozilla-b2g/" />
+  <remote name="mozilla" fetch="https://github.com/mozilla/" />
+  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases" />
+  <remote name="apitrace" fetch="https://github.com/apitrace/" />
+  <default revision="refs/tags/android-4.0.4_r2.1" remote="caf" sync-j="4" />
 
   <!-- Gonk specific things and forks -->
   <project path="build" name="platform_build" remote="b2g" revision="master">

--- a/flatfish.xml
+++ b/flatfish.xml
@@ -1,22 +1,14 @@
 <?xml version="1.0" ?>
 <manifest>
 
-  <remote name="aosp"
-          fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote name="apitrace"
-          fetch="git://github.com/apitrace/" />
-  <remote name="caf"
-          fetch="git://codeaurora.org/" />
-  <remote name="mozillaorg"
-          fetch="https://git.mozilla.org/releases" />
-  <remote name="allwinner"
-          fetch="https://github.com/flatfish-fox/" />
+  <remote name="aosp" fetch="https://android.googlesource.com/" />
+  <remote name="b2g" fetch="https://github.com/mozilla-b2g/" />
+  <remote name="apitrace" fetch="https://github.com/apitrace/" />
+  <remote name="caf" fetch="https://git.mozilla.org/external/caf/" />
+  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases" />
+  <remote name="allwinner" fetch="https://github.com/flatfish-fox/" />
 
-  <default revision="refs/tags/android-4.2.2_r1"
-           remote="aosp"
-           sync-j="4"/>
+  <default revision="refs/tags/android-4.2.2_r1" remote="aosp" sync-j="4"/>
 
   <!-- Gonk specific things and forks -->
   <project path="build" name="platform_build" remote="b2g" revision="b2g-4.2.2_r1">

--- a/fugu.xml
+++ b/fugu.xml
@@ -1,20 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote name="sprd-aosp"
-          fetch="http://sprdsource.spreadtrum.com:8085/b2g/android" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote name="mozilla"
-          fetch="git://github.com/mozilla/" />
-  <remote name="apitrace"
-          fetch="git://github.com/apitrace/" />
-  <remote name="mozillaorg"
-          fetch="https://git.mozilla.org/releases" />
-  <remote name="sprd-b2g"
-          fetch="http://sprdsource.spreadtrum.com:8085/b2g" />
-  <remote name="sprd-github"
-          fetch="https://github.com/sprd-ffos/" />
+  <remote name="sprd-aosp" fetch="http://sprdsource.spreadtrum.com:8085/b2g/android" />
+  <remote name="b2g" fetch="https://github.com/mozilla-b2g/" />
+  <remote name="mozilla" fetch="https://github.com/mozilla/" />
+  <remote name="apitrace" fetch="https://github.com/apitrace/" />
+  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases" />
+  <remote name="sprd-b2g" fetch="http://sprdsource.spreadtrum.com:8085/b2g" />
+  <remote name="sprd-github" fetch="https://github.com/sprd-ffos/" />
   <default revision="refs/tags/android-4.0.4_r2.1"
            remote="sprd-aosp"
            sync-j="4" />

--- a/galaxy-nexus.xml
+++ b/galaxy-nexus.xml
@@ -1,17 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote  name="linaro"
-           fetch="http://android.git.linaro.org/git-ro/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="mozillaorg" 
-      fetch="https://git.mozilla.org/releases" />
-  <remote name="apitrace" fetch="git://github.com/apitrace/" />
+  <remote name="aosp" fetch="https://android.googlesource.com/" />
+  <remote name="b2g" fetch="https://github.com/mozilla-b2g/" />
+  <remote name="linaro" fetch="https://git.mozilla.org/external/linaro/" />
+  <remote name="mozilla" fetch="https://github.com/mozilla/" />
+  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases" />
+  <remote name="apitrace" fetch="https://github.com/apitrace/" />
   <default revision="refs/tags/android-4.0.4_r1.2"
            remote="linaro"
            sync-j="4" />

--- a/galaxy-s2.xml
+++ b/galaxy-s2.xml
@@ -1,17 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote  name="linaro"
-           fetch="http://android.git.linaro.org/git-ro/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="mozillaorg"
-      fetch="https://git.mozilla.org/releases" />
-  <remote name="apitrace" fetch="git://github.com/apitrace/" />
+  <remote name="aosp" fetch="https://android.googlesource.com/" />
+  <remote name="b2g" fetch="https://github.com/mozilla-b2g/" />
+  <remote name="linaro" fetch="https://git.mozilla.org/external/linaro/" />
+  <remote name="mozilla" fetch="https://github.com/mozilla/" />
+  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases" />
+  <remote name="apitrace" fetch="https://github.com/apitrace/" />
   <default revision="refs/tags/android-4.0.4_r1.2"
            remote="linaro"
            sync-j="4" />

--- a/hamachi.xml
+++ b/hamachi.xml
@@ -1,20 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote name="aosp"
-          fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="caf"
-          fetch="git://codeaurora.org/" />
-  <remote name="mozillaorg"
-          fetch="https://git.mozilla.org/releases" />
-  <remote name="apitrace" fetch="git://github.com/apitrace/" />
-  <default revision="b2g/ics_strawberry"
-           remote="caf"
-           sync-j="4" />
+  <remote name="aosp" fetch="https://android.googlesource.com/" />
+  <remote name="b2g" fetch="https://github.com/mozilla-b2g/" />
+  <remote name="mozilla" fetch="https://github.com/mozilla/" />
+  <remote name="caf" fetch="https://git.mozilla.org/external/caf/" />
+  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases" />
+  <remote name="apitrace" fetch="https://github.com/apitrace/" />
+  <default revision="b2g/ics_strawberry" remote="caf" sync-j="4" />
 
   <!-- Gonk specific things and forks -->
   <project path="build" name="platform_build" remote="b2g" revision="master">

--- a/helix.xml
+++ b/helix.xml
@@ -1,19 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote name="aosp"
-          fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote name="mozilla"
-          fetch="git://github.com/mozilla/" />
-  <remote name="caf"
-          fetch="git://codeaurora.org/" />
-  <remote name="mozillaorg"
-          fetch="https://git.mozilla.org/releases" />
-  <default revision="b2g/ics_strawberry"
-           remote="caf"
-           sync-j="4" />
+  <remote name="aosp" fetch="https://android.googlesource.com/" />
+  <remote name="b2g" fetch="https://github.com/mozilla-b2g/" />
+  <remote name="mozilla" fetch="https://github.com/mozilla/" />
+  <remote name="caf" fetch="https://git.mozilla.org/external/caf/" />
+  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases" />
+  <default revision="b2g/ics_strawberry" remote="caf" sync-j="4" />
 
   <!-- Gonk specific things and forks -->
   <project path="build" name="platform_build" remote="b2g" revision="master">

--- a/keon.xml
+++ b/keon.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" ?>
 <manifest>
-  <remote fetch="git://github.com/mozilla-b2g/" name="b2g"/>
-  <remote fetch="git://github.com/gp-b2g/" name="gp-b2g"/>
-  <remote fetch="http://git.mozilla.org/" name="mozillaorg"/>
-  <remote fetch="git://codeaurora.org/" name="caf"/>
-  <remote fetch="git://android.git.linaro.org/" name="linaro"/>
+  <remote fetch="https://github.com/mozilla-b2g/" name="b2g"/>
+  <remote fetch="https://github.com/gp-b2g/" name="gp-b2g"/>
+  <remote fetch="https://git.mozilla.org/" name="mozillaorg"/>
+  <remote fetch="https://git.mozilla.org/external/caf/" name="caf"/>
+  <remote fetch="https://git.mozilla.org/external/linaro/" name="linaro"/>
   <remote name="QRD" fetch="git://codeaurora.org/quic/qrd-android" />
-  <remote name="apitrace" fetch="git://github.com/apitrace/" />
+  <remote name="apitrace" fetch="https://github.com/apitrace/" />
   <default remote="QRD" revision="ics_master_qrd_101" sync-j="9"/>
 
   <!-- Gonk specific things and forks -->

--- a/leo.xml
+++ b/leo.xml
@@ -1,21 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote name="aosp"
-          fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="caf"
-          fetch="git://codeaurora.org/" />
-  <remote name="mozillaorg"
-          fetch="https://git.mozilla.org/releases" />
-  <remote name="apitrace" fetch="git://github.com/apitrace/" />
-
-  <default revision="b2g/ics_strawberry"
-           remote="caf"
-           sync-j="4" />
+  <remote name="aosp" fetch="https://android.googlesource.com/" />
+  <remote name="b2g" fetch="https://github.com/mozilla-b2g/" />
+  <remote name="mozilla" fetch="https://github.com/mozilla/" />
+  <remote name="caf" fetch="https://git.mozilla.org/external/caf/" />
+  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases" />
+  <remote name="apitrace" fetch="https://github.com/apitrace/" />
+  <default revision="b2g/ics_strawberry" remote="caf" sync-j="4" />
 
   <!-- Gonk specific things and forks -->
   <project path="build" name="platform_build" remote="b2g" revision="master">

--- a/nexus-s-4g.xml
+++ b/nexus-s-4g.xml
@@ -1,17 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote  name="linaro"
-           fetch="http://android.git.linaro.org/git-ro/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="mozillaorg"
-      fetch="https://git.mozilla.org/releases" />
-  <remote name="apitrace" fetch="git://github.com/apitrace/" />
+  <remote name="aosp" fetch="https://android.googlesource.com/" />
+  <remote name="b2g" fetch="https://github.com/mozilla-b2g/" />
+  <remote name="linaro" fetch="https://git.mozilla.org/external/linaro/" />
+  <remote name="mozilla" fetch="https://github.com/mozilla/" />
+  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases" />
+  <remote name="apitrace" fetch="https://github.com/apitrace/" />
   <default revision="refs/tags/android-4.0.4_r1.2"
            remote="linaro"
            sync-j="4" />

--- a/nexus-s.xml
+++ b/nexus-s.xml
@@ -1,20 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote  name="caf"
-          fetch="git://codeaurora.org/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="mozillaorg" 
-      fetch="https://git.mozilla.org/releases" />
-  <remote name="apitrace" fetch="git://github.com/apitrace/" />
-  <default revision="refs/tags/android-4.0.4_r1.2"
-           remote="caf"
-           sync-j="4" />
+  <remote name="aosp" fetch="https://android.googlesource.com/" />
+  <remote name="b2g" fetch="https://github.com/mozilla-b2g/" />
+  <remote name="caf" fetch="https://git.mozilla.org/external/caf/" />
+  <remote name="mozilla" fetch="https://github.com/mozilla/" />
+  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases" />
+  <remote name="apitrace" fetch="https://github.com/apitrace/" />
+  <default revision="refs/tags/android-4.0.4_r1.2" remote="caf" sync-j="4" />
 
   <!-- Gonk specific things and forks -->
   <project path="build" name="platform_build" remote="b2g" revision="master">

--- a/optimus-l5.xml
+++ b/optimus-l5.xml
@@ -1,19 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="caf"
-          fetch="git://codeaurora.org/" />
-  <remote  name="linaro"
-           fetch="http://android.git.linaro.org/git-ro/" />
-  <remote name="mozillaorg"
-           fetch="https://git.mozilla.org/releases" />
-  <remote name="apitrace" fetch="git://github.com/apitrace/" />
+  <remote name="aosp" fetch="https://android.googlesource.com/" />
+  <remote name="b2g" fetch="https://github.com/mozilla-b2g/" />
+  <remote name="mozilla" fetch="https://github.com/mozilla/" />
+  <remote name="caf" fetch="https://git.mozilla.org/external/caf/" />
+  <remote name="linaro" fetch="https://git.mozilla.org/external/linaro/" />
+  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases" />
+  <remote name="apitrace" fetch="https://github.com/apitrace/" />
   <default revision="ics_chocolate"
            remote="caf"
            sync-j="4" />

--- a/otoro.xml
+++ b/otoro.xml
@@ -1,22 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote name="b2gmozilla"
-          fetch="https://git.mozilla.org/b2g" />
-  <remote name="b2g"
-           fetch="git://github.com/mozilla-b2g/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="caf"
-          fetch="git://codeaurora.org/" />
-  <remote name="mozillaorg"
-           fetch="https://git.mozilla.org/releases" />
-  <remote name="apitrace" fetch="git://github.com/apitrace/" />
-  <default revision="ics_chocolate_rb4.2"
-           remote="caf"
-           sync-j="4" />
+  <remote name="aosp" fetch="https://android.googlesource.com/" />
+  <remote name="b2gmozilla" fetch="https://git.mozilla.org/b2g" />
+  <remote name="b2g" fetch="https://github.com/mozilla-b2g/" />
+  <remote name="mozilla" fetch="https://github.com/mozilla/" />
+  <remote name="caf" fetch="https://git.mozilla.org/external/caf/" />
+  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases" />
+  <remote name="apitrace" fetch="https://github.com/apitrace/" />
+  <default revision="ics_chocolate_rb4.2" remote="caf" sync-j="4" />
 
   <!-- Gonk specific things and forks -->
   <project path="build" name="platform_build" remote="b2g" revision="master">

--- a/pandaboard.xml
+++ b/pandaboard.xml
@@ -1,19 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote  name="aosp"
-           fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote  name="linaro"
-           fetch="http://android.git.linaro.org/git-ro/" />
-  <remote name="caf"
-          fetch="git://codeaurora.org/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
-  <remote name="mozillaorg"
-      fetch="https://git.mozilla.org/releases" />
-  <remote name="apitrace" fetch="git://github.com/apitrace/" />
+  <remote name="aosp" fetch="https://android.googlesource.com/" />
+  <remote name="b2g" fetch="https://github.com/mozilla-b2g/" />
+  <remote name="linaro" fetch="https://git.mozilla.org/external/linaro/" />
+  <remote name="caf" fetch="https://git.mozilla.org/external/caf/" />
+  <remote name="mozilla" fetch="https://github.com/mozilla/" />
+  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases" />
+  <remote name="apitrace" fetch="https://github.com/apitrace/" />
   <default revision="refs/tags/android-4.0.4_r2.1"
            remote="caf"
            sync-j="4" />

--- a/peak.xml
+++ b/peak.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" ?>
 <manifest>
-  <remote fetch="git://github.com/mozilla-b2g/" name="b2g"/>
-  <remote fetch="git://github.com/gp-b2g/" name="gp-b2g"/>
-  <remote fetch="http://git.mozilla.org/" name="mozillaorg"/>
-  <remote fetch="git://codeaurora.org/" name="caf"/>
-  <remote fetch="git://android.git.linaro.org/" name="linaro"/>
+  <remote fetch="https://github.com/mozilla-b2g/" name="b2g"/>
+  <remote fetch="https://github.com/gp-b2g/" name="gp-b2g"/>
+  <remote fetch="https://git.mozilla.org/" name="mozillaorg"/>
+  <remote fetch="https://git.mozilla.org/external/caf/" name="caf"/>
+  <remote fetch="https://git.mozilla.org/external/linaro/" name="linaro"/>
   <remote name="QRD" fetch="git://codeaurora.org/quic/qrd-android"/>
-  <remote name="apitrace" fetch="git://github.com/apitrace/" />
+  <remote name="apitrace" fetch="https://github.com/apitrace/" />
   <default remote="QRD" revision="ics_master_qrd_101" sync-j="9"/>
 
   <!-- Gonk specific things and forks -->

--- a/tara.xml
+++ b/tara.xml
@@ -2,14 +2,12 @@
 <manifest>
 
   <remote name="b2g" fetch="https://github.com/mozilla-b2g/"/>
-  <remote name="mozilla" fetch="git://github.com/mozilla/"/>
-  <remote name="linaro" fetch="git://android.git.linaro.org/"/>
+  <remote name="mozilla" fetch="https://github.com/mozilla/"/>
+  <remote name="linaro" fetch="https://git.mozilla.org/external/linaro/"/>
   <remote name="mozillaorg" fetch="https://git.mozilla.org/releases/"/>
   <remote name="sprd" fetch="http://sprdsource.spreadtrum.com:8085/b2g/" />
-  <remote name="apitrace" fetch="git://github.com/apitrace/" />
-  <default revision="sprdroid4.0.3_vlx_3.0_b2g"
-           remote="sprd"
-           sync-j="4" />
+  <remote name="apitrace" fetch="https://github.com/apitrace/" />
+  <default revision="sprdroid4.0.3_vlx_3.0_b2g" remote="sprd" sync-j="4" />
 
   <!-- Gonk specific things and forks -->
   <project name="gecko.git" path="gecko" remote="mozillaorg" revision="master" />

--- a/tarako.xml
+++ b/tarako.xml
@@ -2,9 +2,9 @@
 <manifest>
 
   <remote name="sprd-aosp" fetch="http://sprdsource.spreadtrum.com:8085/b2g/android" />
-  <remote name="b2g" fetch="git://github.com/mozilla-b2g/" />
-  <remote name="mozilla" fetch="git://github.com/mozilla/" />
-  <remote name="apitrace" fetch="git://github.com/apitrace/" />
+  <remote name="b2g" fetch="https://github.com/mozilla-b2g/" />
+  <remote name="mozilla" fetch="https://github.com/mozilla/" />
+  <remote name="apitrace" fetch="https://github.com/apitrace/" />
   <remote name="mozillaorg" fetch="https://git.mozilla.org/releases" />
   <remote name="sprd-b2g" fetch="http://sprdsource.spreadtrum.com:8085/b2g" />
   <default revision="refs/tags/android-4.0.4_r2.1" remote="sprd-aosp" sync-j="4" />

--- a/wasabi.xml
+++ b/wasabi.xml
@@ -1,20 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote name="aosp"
-          fetch="https://android.googlesource.com/" />
-  <remote name="b2g"
-          fetch="git://github.com/mozilla-b2g/" />
-  <remote name="mozilla"
-          fetch="git://github.com/mozilla/" />
-  <remote name="caf"
-          fetch="git://codeaurora.org/" />
-  <remote name="mozillaorg"
-          fetch="https://git.mozilla.org/releases" />
-  <remote name="apitrace" fetch="git://github.com/apitrace/" />
-  <default revision="ics_chocolate_rb4.2"
-           remote="caf"
-           sync-j="4" />
+  <remote name="aosp" fetch="https://android.googlesource.com/" />
+  <remote name="b2g" fetch="https://github.com/mozilla-b2g/" />
+  <remote name="mozilla" fetch="https://github.com/mozilla/" />
+  <remote name="caf" fetch="https://git.mozilla.org/external/caf/" />
+  <remote name="mozillaorg" fetch="https://git.mozilla.org/releases" />
+  <remote name="apitrace" fetch="https://github.com/apitrace/" />
+  <default revision="ics_chocolate_rb4.2" remote="caf" sync-j="4" />
 
   <!-- Gonk specific things and forks -->
   <project path="build" name="platform_build" remote="b2g" revision="master">


### PR DESCRIPTION
This patch changes where a certain number of repositories are fetched:
- linaro.org repositories are now taken from the git.mozilla.org mirror
- codeaurora.org repositories likewise
- all repositories fetched from GitHub are now pulled via HTTPS
