### PR TITLE
Bug 1054934: Add libnfcemu to JB emulator

### DIFF
--- a/emulator-jb.xml
+++ b/emulator-jb.xml
@@ -10,6 +10,7 @@
   <project name="device/generic/armv7-a-neon" path="device/generic/armv7-a-neon"/>
   <project path="device/generic/goldfish" name="device_generic_goldfish" remote="b2g" revision="b2g-4.3_r2.1" />
   <project name="platform/external/libnfc-nci" path="external/libnfc-nci"/>
+  <project name="libnfcemu" path="platform/external/libnfcemu" remote="b2g" revision="master" />
   <project name="platform_external_qemu" path="external/qemu" remote="b2g" revision="b2g-jellybean"/>
   <project name="platform/external/wpa_supplicant_8" path="external/wpa_supplicant_8"/>
   <project name="platform_hardware_ril" path="hardware/ril" remote="b2g" revision="b2g-jellybean"/>


### PR DESCRIPTION
'libnfcemu' is a shared library that provides NFC support for the
JB emulator.

Change-Id: I36af876c5dd2df958f26da78616622c8b797ebce
