### PR TITLE
Bug 1079087 - Update to the latest bluedroid stack change list

### DIFF
--- a/flame-kk.xml
+++ b/flame-kk.xml
@@ -149,7 +149,7 @@
   <project name="device-flame" path="device/t2m/flame" remote="b2g" revision="kitkat"/>
   <project name="codeaurora_kernel_msm" path="kernel" remote="b2g" revision="t2m-flame-3.4-kk"/>
   <project name="kernel_lk" path="bootable/bootloader/lk" remote="b2g" revision="foxfone-one-v1.4"/>
-  <project name="platform/external/bluetooth/bluedroid" path="external/bluetooth/bluedroid" revision="082a1f98422e6a6b56f61218d6fcf465e85d4c58"/>
+  <project name="platform/external/bluetooth/bluedroid" path="external/bluetooth/bluedroid" revision="30b96dfca99cb384bf520a16b81f3aba56f09907"/>
   <project name="platform/external/wpa_supplicant_8" path="external/wpa_supplicant_8" revision="5b71e40213f650459e95d35b6f14af7e88d8ab62"/>
   <project name="platform_external_libnfc-nci" path="external/libnfc-nci" remote="t2m" revision="4186bdecb4dae911b39a8202252cc2310d91b0be"/>
   <project name="platform/frameworks/av" path="frameworks/av" revision="9e88d2eb335f00d9d9af18f663f9d3e55b019bf8"/>


### PR DESCRIPTION
commit 30b96dfca99cb384bf520a16b81f3aba56f09907
Merge: b2af89a cb9b8d2
Author: Linux Build Service Account lnxbuild@localhost
Date:   Thu Sep 18 06:58:19 2014 -0700

```
Merge "Remove double references to close syscall for hci_event_sock socket"
```
