### PR TITLE
Freeze gecko/gaia versions to work around bug 1085599, for now.

### DIFF
--- a/rpi.xml
+++ b/rpi.xml
@@ -22,8 +22,13 @@
     <copyfile src="core/root.mk" dest="Makefile" />
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
-  <project path="gaia" name="gaia.git" remote="mozillaorg" revision="master" />
-  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="master" />
+  <!-- Gecko and gaia are currently frozen to these sha1's because
+       armv6 support is broken in gecko.  See
+       https://bugzilla.mozilla.org/show_bug.cgi?id=1085599 -->
+  <project path="gaia" name="gaia.git" remote="mozillaorg"
+           revision="457a54fc3200b80e4f5e1cd3acaa062309230732" />
+  <project path="gecko" name="gecko.git" remote="mozillaorg"
+           revision="b7b2dc40de355add3634cc972fc31521a8daeed3" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="librecovery" name="librecovery" remote="b2g" revision="master" />


### PR DESCRIPTION
Working on a real-ish fix, but not ready yet.

Since this PR only touches the rpi manifest which isn't on CI yet, I'm going to directly merge it.
