### PR TITLE
Bug 971353 - Fix "No SIM card" on Alcatel One Touch Fire by removing rilproxy binary

### DIFF
--- a/hamachi.xml
+++ b/hamachi.xml
@@ -24,7 +24,6 @@
   <project path="gaia" name="gaia.git" remote="mozillaorg" revision="master" />
   <project path="gecko" name="gecko.git" remote="mozillaorg" revision="master" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
-  <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="librecovery" name="librecovery" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />
   <project path="external/apitrace" name="apitrace" remote="apitrace" revision="master" />


### PR DESCRIPTION
This patch removes the `/system/bin/rilproxy` binary on the hamachi platform to resolve [bug 971353](https://bugzilla.mozilla.org/show_bug.cgi?id=971353), as suggested by Michael Wu.

Previous attempt in #222.
