### PR TITLE
Bug 1091066 - Continuous Integration in travis-ci for b2g-manifest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: python
+python:
+  - "2.7"
+
+script:
+  - bash ./run_travis_tests.sh

--- a/run_travis_tests.sh
+++ b/run_travis_tests.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# See https://travis-ci.org/mozilla-b2g/b2g-manifest
+
+# This script is run by travis for the CI of b2g-manifest.
+# It is designed to catch problems that would otherwise only
+# be found when b2g bumper bot runs in production, that
+# potentially can cause tree closures.
+
+# It installs and runs b2g bumper locally, without committing
+# nor pushing back to hg, to check that repos referenced exist
+# and are readable, referenced heads/tags exist, and that they
+# are correctly mirrored on git.mozilla.org.
+
+# Gaia is excluded from testing, since access to cruncher is
+# required to map hg sha to git sha, whereas these tests are
+# more concerned with invalid repos/branches/tags getting
+# added to a manifest.
+
+set -xve
+B2G_MANIFEST_DIR="$(pwd)"
+cd ..
+
+echo "Installing mozharness..."
+echo "Current directory: '$(pwd)'"
+git clone https://github.com/mozilla/build-mozharness mozharness
+echo "Installing tools..."
+git clone https://github.com/mozilla/build-tools tools
+
+# create a config file with the correct location for gittool.py
+# to be added to list of configs to be passed to mozharness...
+
+GITTOOL_PATH="$(find "$(pwd)/tools" -name gittool.py)"
+cat << EOF > "${B2G_MANIFEST_DIR}/travis-mozharness-config.py"
+config = {
+    "exes": {
+        "gittool.py": ["${GITTOOL_PATH}"],
+    },
+}
+EOF
+
+# rather than use mozharness to checkout b2g-manifest, use the one checked out by travis already...
+mkdir build
+ln -s "${B2G_MANIFEST_DIR}" build/manifests
+
+echo "Running b2g bumper..."
+for config_file in mozharness/configs/b2g_bumper/*.py; do
+    mozharness/scripts/b2g_bumper.py -c "${config_file}" -c "${B2G_MANIFEST_DIR}/travis-mozharness-config.py" --massage-manifests
+done
+
+echo "All b2g bumper steps succeeded!"


### PR DESCRIPTION
After this is merged in, someone with admin access should be enable travis testing from:
https://travis-ci.org/profile/mozilla-b2g

From this point on, it would make sense only to merge pull requests if the user's fork has also passed the tests in travis (each user will need to enable travis testing for their own fork).

This should avoid bustage from b2g-manifest hitting gecko and causing tree closures.

The new CI checks that b2g bumper can run successfully against the b2g-manifest manifests.
