### PR TITLE
Fix git-linaro URL for galaxy-nexus

### DIFF
--- a/galaxy-nexus.xml
+++ b/galaxy-nexus.xml
@@ -6,7 +6,7 @@
   <remote name="b2g"
           fetch="git://github.com/mozilla-b2g/" />
   <remote  name="linaro"
-           fetch="http://android.git.linaro.org/git-ro/" />
+           fetch="git://android.git.linaro.org/" />
   <remote name="mozilla"
 	  fetch="git://github.com/mozilla/" />
   <remote name="mozillaorg" 


### PR DESCRIPTION
Update the linaro URL with the latest one to be able to fetch the latest version for the galaxy nexus.

Fixes #256 .
