### PR TITLE
Bug 1122932 - [flatfish] Upgrade toolchain to gcc-4.8

### DIFF
--- a/flatfish.xml
+++ b/flatfish.xml
@@ -41,6 +41,7 @@
   <project path="prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.7-4.6" name="platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.7-4.6" groups="linux"/>
   <project path="prebuilts/gcc/linux-x86/arm/arm-eabi-4.6" name="platform/prebuilts/gcc/linux-x86/arm/arm-eabi-4.6" groups="linux,arm"/>
   <project path="prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.6" name="platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.6" groups="linux,arm"/>
+  <project path="prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.8" name="platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.8" groups="linux,arm" revision="master" />
   <project path="device/sample" name="device/sample"/>
   <project path="device/common" name="device/common"/>
   <project path="abi/cpp" name="platform/abi/cpp"/>


### PR DESCRIPTION
* Change manifest to download gcc-4.8 toolchain

Change-Id: Ic64c1972ac8af00bbc19e97892272cf515661eb4