### PR TITLE
Bug 1123092 - [RPi] Upgrade toolchain to gcc.4.8

### DIFF
--- a/rpi.xml
+++ b/rpi.xml
@@ -101,6 +101,7 @@
   <project path="libcore" name="platform/libcore" />
   <project path="ndk" name="platform/ndk" />
   <project path="prebuilt" name="platform/prebuilt" />
+  <project path="prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.8" name="platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.8" revision="master" />
   <!-- TODO: can we drop this? -->
   <project path="system/bluetooth" name="platform/system/bluetooth" />
   <project path="system/core" name="platform_system_core"


### PR DESCRIPTION
* Change manifest to download gcc-4.8 based toolchain