### PR TITLE
Bug 1116074: add emulator-l and emulator-x86-l

### DIFF
--- a/emulator-l.xml
+++ b/emulator-l.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<manifest>
+
+  <include name="base-l-aosp.xml" />
+
+  <default remote="caf" revision="refs/tags/android-5.0.0_r6" sync-j="4"/>
+
+  <!-- Emulator specific things -->
+  <project name="device/generic/armv7-a-neon" path="device/generic/armv7-a-neon"/>
+  <project name="device_generic_goldfish" path="device/generic/goldfish" remote="b2g" revision="b2g-5.0.0_r6" />
+  <project name="platform_external_qemu" path="external/qemu" remote="b2g" revision="b2g-lollipop"/>
+  <project name="platform/external/wpa_supplicant_8" path="external/wpa_supplicant_8"/>
+  <project name="android-sdk" path="sdk" remote="b2g" revision="b2g-5.0.0_r6"/>
+  <project name="platform_hardware_ril" path="hardware/ril" remote="b2g" revision="b2g-lollipop"/>
+
+</manifest>
+

--- a/emulator-x86-l.xml
+++ b/emulator-x86-l.xml
@@ -1,0 +1,1 @@
+emulator-l.xml


### PR DESCRIPTION
This pr add two new emulator targets emulator-l and emulator-x86-l. Please see [bug 1116074](https://bugzilla.mozilla.org/show_bug.cgi?id=1116074) for more information.
