### PR TITLE
Bug 1127371: Remove Negatus from Pandaboard manifest

### DIFF
--- a/pandaboard.xml
+++ b/pandaboard.xml
@@ -9,8 +9,6 @@
            fetch="http://android.git.linaro.org/git-ro/" />
   <remote name="caf"
           fetch="git://codeaurora.org/" />
-  <remote name="mozilla"
-	  fetch="git://github.com/mozilla/" />
   <remote name="mozillaorg"
       fetch="https://git.mozilla.org/releases" />
   <remote name="apitrace" fetch="git://github.com/apitrace/" />
@@ -110,7 +108,6 @@
   <project path="hardware/ti/omap4xxx" name="platform/hardware/ti/omap4xxx" />
   <project path="hardware/ti/wlan" name="platform/hardware/ti/wlan" revision="60dfeb6e4448bfed707946ebca6612980f525e69" />
   <project path="hardware/ti/wpan" name="platform/hardware/ti/wpan" revision="3ece7d9e08052989401e008bc397dbcd2557cfd0" />
-  <project path="external/negatus" name="Negatus" remote="mozilla" revision="master" />
   <project path="external/orangutan" name="orangutan" remote="b2g" revision="master" />
 
 </manifest>


### PR DESCRIPTION
Negatus is not required and requires external dependencies (NSPR)
for building. This commit removes it from the manifest.

Change-Id: Ic558b82bcf4e2e08098ee045015412d170359f48