### PR TITLE
Bug 1131892 - Override libhardware_legacy to fix device crashed by wifi.

### DIFF
--- a/base-kk-caf.xml
+++ b/base-kk-caf.xml
@@ -9,7 +9,9 @@
   <remove-project name="platform/frameworks/native"/>
   <remove-project name="platform/hardware/libhardware"/>
   <remove-project name="platform/external/bluetooth/bluedroid"/>
+  <remove-project name="platform/hardware/libhardware_legacy"/>
   <remove-project name="platform/system/media"/>
+  <project name="platform/hardware/libhardware_legacy" path="hardware/libhardware_legacy" revision="LNX.LF.3.5.2.1_1"/>
   <project name="platform/system/media" path="system/media" revision="LNX.LF.3.5.2.1_1"/>
 
 </manifest>


### PR DESCRIPTION
Change-Id: Ice95ce37cdf48df49a3732ebac872f757eb9ae7e