### PR TITLE
change rev for f2fs-tools

### DIFF
--- a/nexus-5-l.xml
+++ b/nexus-5-l.xml
@@ -61,7 +61,7 @@
   <project name="platform/external/e2fsprogs" path="external/e2fsprogs" revision="6bf16cd4eefe67583db6efd8ecf72571f5d8d249"/>
   <project name="platform/external/elfutils" path="external/elfutils" revision="17541cad868bfd18e6148d4fa3dc3a7d20a25732"/>
   <project name="platform/external/expat" path="external/expat" revision="f49624e0fef9915a3a8326b46e91cb4c464555e4"/>
-  <project name="platform/external/f2fs-tools" path="external/f2fs-tools" revision="756442210a6c95ffe0cd2c43335eb0777bbc428d"/>
+  <project name="platform/external/f2fs-tools" path="external/f2fs-tools" revision="dc532e5316488cc41668e918c2105f6c051d0767"/>
   <project name="platform/external/fdlibm" path="external/fdlibm" revision="de3b2c981c66345b51fbf0822e4058c36eecb9ac"/>
   <project name="platform/external/flac" path="external/flac" revision="4477379717f7b0fa20a8f0614f970c70d373cb7b"/>
   <project name="platform/external/freetype" path="external/freetype" revision="33a0a0c5b597e7b5ab2cada25ae411d9bb42ff26"/>


### PR DESCRIPTION
Change-Id: I72f9b0a0115f70aedc5620174dc4f96cbf1d701c

The hash revision is not in the repo, so it causes failure.  Replaced with a hash that is in the repo.