### PR TITLE
Revert "Bug 1147266 - Update nexus-5-l manifest to b2g-5.1.0_r1. r=mwu"

### DIFF
--- a/base-l-aosp.xml
+++ b/base-l-aosp.xml
@@ -7,9 +7,9 @@
   <remove-project name="platform/frameworks/base"/>
   <remove-project name="platform/frameworks/wilhelm"/>
   <remove-project name="platform/system/core"/>
-  <project name="platform_frameworks_av" path="frameworks/av" remote="b2g" revision="b2g-5.1.0_r1"/>
-  <project name="platform_frameworks_base" path="frameworks/base" remote="b2g" revision="b2g-5.1.0_r1"/>
-  <project name="platform_frameworks_wilhelm" path="frameworks/wilhelm" remote="b2g" revision="b2g-5.1.0_r1"/>
-  <project name="platform_system_core" path="system/core" remote="b2g" revision="b2g-5.1.0_r1"/>
+  <project name="platform_frameworks_av" path="frameworks/av" remote="b2g" revision="b2g-5.0.0_r6"/>
+  <project name="platform_frameworks_base" path="frameworks/base" remote="b2g" revision="b2g-5.0.0_r6"/>
+  <project name="platform_frameworks_wilhelm" path="frameworks/wilhelm" remote="b2g" revision="b2g-5.0.0_r6"/>
+  <project name="platform_system_core" path="system/core" remote="b2g" revision="b2g-5.0.0_r6"/>
 
 </manifest>

--- a/base-l.xml
+++ b/base-l.xml
@@ -9,7 +9,7 @@
   <remote fetch="https://git.mozilla.org/releases" name="mozillaorg"/>
 
   <!-- B2G specific things. -->
-  <project name="platform_build" path="build" remote="b2g" revision="b2g-5.1.0_r1">
+  <project name="platform_build" path="build" remote="b2g" revision="b2g-5.0.0_r6">
     <copyfile dest="Makefile" src="core/root.mk"/>
   </project>
   <project name="gaia" path="gaia" remote="mozillaorg" revision="master"/>
@@ -133,9 +133,9 @@
   <project name="platform/libcore" path="libcore"/>
   <project name="platform/libnativehelper" path="libnativehelper"/>
   <project name="platform/ndk" path="ndk"/>
-  <project name="platform_prebuilts_misc" path="prebuilts/misc" remote="b2g" revision="b2g-5.1.0_r1"/>
+  <project name="platform_prebuilts_misc" path="prebuilts/misc" remote="b2g" revision="b2g-5.0.0_r6"/>
   <project name="platform/prebuilts/ndk" path="prebuilts/ndk"/>
-  <project name="platform_prebuilts_qemu-kernel" path="prebuilts/qemu-kernel" remote="b2g" revision="b2g-5.1.0_r1"/>
+  <project name="platform_prebuilts_qemu-kernel" path="prebuilts/qemu-kernel" remote="b2g" revision="b2g-5.0.0_r6"/>
   <project name="platform/prebuilts/sdk" path="prebuilts/sdk"/>
   <project name="platform/prebuilts/tools" path="prebuilts/tools"/>
   <project name="platform_system_bluetoothd" path="system/bluetoothd" remote="b2g" revision="master"/>

--- a/nexus-5-l.xml
+++ b/nexus-5-l.xml
@@ -2,18 +2,18 @@
 
   <include name="base-l-aosp.xml"/>
 
-  <default remote="caf" revision="refs/tags/android-5.1.0_r1" sync-j="4"/>
+  <default remote="caf" revision="refs/tags/android-5.0.0_r6" sync-j="4"/>
 
   <!-- Nexus 5 specific things -->
   <project name="device/generic/armv7-a-neon" path="device/generic/armv7-a-neon"/>
-  <project name="device-hammerhead" path="device/lge/hammerhead" remote="b2g" revision="b2g-5.1.0_r1"/>
-  <project name="device_lge_hammerhead-kernel" path="device/lge/hammerhead-kernel" remote="b2g" revision="b2g-5.1.0_r1"/>
+  <project name="device-hammerhead" path="device/lge/hammerhead" remote="b2g" revision="b2g-5.0.0_r6"/>
+  <project name="device_lge_hammerhead-kernel" path="device/lge/hammerhead-kernel" remote="b2g" revision="b2g-5.0.0_r6"/>
   <project name="platform/external/libnfc-nci" path="external/libnfc-nci"/>
   <project name="platform/external/wpa_supplicant_8" path="external/wpa_supplicant_8"/>
   <project name="platform/hardware/broadcom/libbt" path="hardware/broadcom/libbt"/>
   <project name="platform/hardware/broadcom/wlan" path="hardware/broadcom/wlan"/>
   <project name="platform/hardware/qcom/audio" path="hardware/qcom/audio"/>
-  <project name="hardware_qcom_display" path="hardware/qcom/display" remote="b2g" revision="b2g-5.1.0_r1"/>
+  <project name="hardware_qcom_display" path="hardware/qcom/display" remote="b2g" revision="b2g-5.0.0_r6"/>
   <project name="platform/hardware/qcom/keymaster" path="hardware/qcom/keymaster"/>
   <project name="platform/hardware/qcom/media" path="hardware/qcom/media"/>
   <project name="platform/hardware/qcom/msm8x74" path="hardware/qcom/msm8x74"/>


### PR DESCRIPTION
Reverts mozilla-b2g/b2g-manifest#315 because not all dependent patches landed with review.