### PR TITLE
Bug 1163968 - Update emulator-ics external/qemu to branch b2g-ics. r=seinlin

### DIFF
--- a/emulator.xml
+++ b/emulator.xml
@@ -28,7 +28,7 @@
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="hardware/ril" name="platform_hardware_ril" remote="b2g" revision="b2g-ril_v7"/>
-  <project path="external/qemu" name="platform_external_qemu" remote="b2g" revision="master"/>
+  <project path="external/qemu" name="platform_external_qemu" remote="b2g" revision="b2g-ics"/>
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />
   <project path="external/apitrace" name="apitrace" remote="apitrace" revision="refs/tags/6.1" />
 


### PR DESCRIPTION
Please see [bug 1128837](https://bugzilla.mozilla.org/show_bug.cgi?id=1163968).