### PR TITLE
Bug 1165276 - Don't run the b2g-manifest travis tests on aries. r=catlee

### DIFF
--- a/run_travis_tests.sh
+++ b/run_travis_tests.sh
@@ -56,7 +56,7 @@ echo "Running b2g bumper..."
 # !!!!!
 # !!!!! See https://bugzilla.mozilla.org/show_bug.cgi?id=1153802 for more details
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-for config_file in mozharness/configs/b2g_bumper/{master,aries}.py; do
+for config_file in mozharness/configs/b2g_bumper/master.py; do
     mozharness/scripts/b2g_bumper.py -c "${config_file}" -c "${B2G_MANIFEST_DIR}/travis-mozharness-config.py" --import-git-ref-cache --massage-manifests --export-git-ref-cache
 done
 


### PR DESCRIPTION
mozharness/configs/b2g_bumper/aries.py has been removed in [bug 1144994](https://bugzilla.mozilla.org/show_bug.cgi?id=1144994), we need
to do corresponding change in b2g-manifest/run_travis_tests.sh as well.