### PR TITLE
Part 3: Bug 1180216 - Use forked external/sepolicy, remove qcom sepolicy r=seinlin

### DIFF
--- a/flame-l.xml
+++ b/flame-l.xml
@@ -14,11 +14,12 @@
   <project name="device/generic/armv7-a-neon" path="device/generic/armv7-a-neon"/>
   <project name="device/qcom/common" path="device/qcom/common"/>
   <project name="platform/vendor/qcom/msm8610" path="device/qcom/msm8610"/>
-  <project name="device/qcom/sepolicy" path="device/qcom/sepolicy"/>
   <project name="device-flame" path="device/t2m/flame" remote="b2g" revision="lollipop"/>
   <remove-project name="platform/external/bluetooth/bluedroid"/>
   <project name="platform_external_bluetooth_bluedroid" path="external/bluetooth/bluedroid" remote="b2g" revision="foxfone-one-lollipop"/>
   <project name="android_platform_external_libnfc-nci" path="external/libnfc-nci" remote="t2m" revision="foxfone-one-lollipop"/>
+  <remove-project name="platform/external/sepolicy"/>
+  <project name="platform_external_sepolicy" path="external/sepolicy" remote="b2g" revision="LA.BF.1.1.2_rb1.12"/>
   <project name="platform_external_libnfc-pn547" path="external/libnfc-pn547" remote="b2g" revision="master"/>
   <project name="platform/external/wpa_supplicant_8" path="external/wpa_supplicant_8"/>
   <remove-project name="platform/frameworks/av"/>


### PR DESCRIPTION
In Part 2, the policies form device/qcom/sepolicy have been moved to device/t2m/flame, therefore they are deleted here.