### PR TITLE
Bug 1184418 - [emulator-l] Switch external/qemu to b2g-studio-1.3 branch

### DIFF
--- a/emulator-l.xml
+++ b/emulator-l.xml
@@ -9,7 +9,7 @@
   <project name="device/generic/armv7-a-neon" path="device/generic/armv7-a-neon"/>
   <project name="device_generic_goldfish" path="device/generic/goldfish" remote="b2g" revision="b2g-5.1.0_r1"/>
   <!-- external/qemu for emulator-l need to be updated in bug-1121378 -->
-  <project name="platform_external_qemu" path="external/qemu" remote="b2g" revision="b2g-lollipop"/>
+  <project name="platform_external_qemu" path="external/qemu" remote="b2g" revision="b2g-studio-1.3"/>
   <project name="platform_external_wpa_supplicant_8" path="external/wpa_supplicant_8" remote="b2g" revision="b2g-5.1.0_r1"/>
   <project name="platform/development" path="development"/>
   <project name="android-sdk" path="sdk" remote="b2g" revision="b2g-5.1.0_r1"/>


### PR DESCRIPTION
Please see [bug 1181481](https://bugzilla.mozilla.org/show_bug.cgi?id=1181481).