### PR TITLE
Bug 1134982 - Switch hardware/ril to proper branch for emualtor-kk and emulatro-l

### DIFF
--- a/emulator-kk.xml
+++ b/emulator-kk.xml
@@ -11,7 +11,7 @@
   <project name="platform_external_qemu" path="external/qemu" remote="b2g" revision="b2g-kitkat"/>
   <project name="platform/external/libnfc-nci" path="external/libnfc-nci"/>
   <project name="platform_external_wpa_supplicant_8" path="external/wpa_supplicant_8" remote="b2g" revision="b2g-4.4.2_r1"/>
-  <project name="platform_hardware_ril" path="hardware/ril" remote="b2g" revision="master"/>
+  <project name="platform_hardware_ril" path="hardware/ril" remote="b2g" revision="b2g-kitkat"/>
   <project name="platform_system_nfcd" path="system/nfcd" remote="b2g" revision="master"/>
   <project name="platform/development" path="development"/>
   <project name="android-sdk" path="sdk" remote="b2g" revision="b2g-4.4.2_r1"/>

--- a/emulator-l.xml
+++ b/emulator-l.xml
@@ -8,13 +8,11 @@
   <!-- Emulator specific things -->
   <project name="device/generic/armv7-a-neon" path="device/generic/armv7-a-neon"/>
   <project name="device_generic_goldfish" path="device/generic/goldfish" remote="b2g" revision="b2g-5.1.0_r1"/>
-  <!-- external/qemu for emulator-l need to be updated in bug-1121378 -->
   <project name="platform_external_qemu" path="external/qemu" remote="b2g" revision="b2g-studio-1.3"/>
   <project name="platform_external_wpa_supplicant_8" path="external/wpa_supplicant_8" remote="b2g" revision="b2g-5.1.0_r1"/>
   <project name="platform/development" path="development"/>
   <project name="android-sdk" path="sdk" remote="b2g" revision="b2g-5.1.0_r1"/>
-  <!-- hardware-ril for emulator-l need to be updated in bug-1113054 -->
-  <project name="platform/hardware/ril" path="hardware/ril"/>
+  <project name="platform_hardware_ril" path="hardware/ril" remote="b2g" revision="b2g-lollipop-mr1"/>
 
 </manifest>
 


### PR DESCRIPTION
Please see [bug 1134982](https://bugzilla.mozilla.org/show_bug.cgi?id=1134982).