### PR TITLE
Bug 1136512 - Sony Z3C - nfcd should build with Z3 compatiable libnfc-nci library

### DIFF
--- a/shinano.xml
+++ b/shinano.xml
@@ -14,7 +14,7 @@
   <remove-project name="platform/bionic"/>
   <project name="platform_bionic" path="bionic" remote="b2g" revision="b2g-4.4.2_r1" />
   <project name="platform_external_bluetooth_bluedroid" path="external/bluetooth/bluedroid" remote="b2g" revision="b2g_kk_3.5"/>
-  <project name="platform/external/libnfc-nci" path="external/libnfc-nci" revision="kk_3.5"/>
+  <project name="platform_external_libnfc-nci" path="external/libnfc-nci" remote="b2g" revision="shinano"/>
   <project name="platform_external_libnfc-pn547" path="external/libnfc-pn547" remote="b2g" revision="master"/>
   <project name="platform/external/wpa_supplicant_8" path="external/wpa_supplicant_8"/>
   <project name="platform_frameworks_av" path="frameworks/av" remote="b2g" revision="shinano"/>


### PR DESCRIPTION
Change-Id: I735b2b9830ea9ded8e696891ef30aae479970e32