### PR TITLE
Bug 1233351 - Manifest fixes to gecko to point to gmo/integration/gecko-dev

### DIFF
--- a/emulator-jb.xml
+++ b/emulator-jb.xml
@@ -8,12 +8,13 @@
   <remote fetch="git://github.com/apitrace/" name="apitrace"/>
   <remote fetch="git://codeaurora.org/" name="caf"/>
   <remote fetch="https://git.mozilla.org/releases" name="mozillaorg"/>
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
 
   <!-- B2G specific things. -->
   <project name="platform_build" path="build" remote="b2g" revision="660169a3d7e034a892359e39135e8c2785a6ad6f">
     <copyfile dest="Makefile" src="core/root.mk"/>
   </project>
-  <project name="gecko.git" path="gecko" remote="mozillaorg" revision="b2g-ota"/>
+  <project name="gecko-dev" path="gecko" remote="mozorg_int" revision="b2g-ota"/>
   <project name="rilproxy" path="rilproxy" remote="b2g" revision="b2g-ota"/>
   <project name="fake-libdvm" path="dalvik" remote="b2g" revision="b2g-ota"/>
   

--- a/emulator-kk.xml
+++ b/emulator-kk.xml
@@ -10,13 +10,14 @@
   <remote fetch="git://github.com/apitrace/" name="apitrace"/>
   <remote fetch="git://codeaurora.org/" name="caf"/>
   <remote fetch="https://git.mozilla.org/releases" name="mozillaorg"/>
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
 
   <!-- B2G specific things. -->
   <project name="platform_build" path="build" remote="b2g" revision="8d83715f08b7849f16a0dfc88f78d5c3a89c0a54">
     <copyfile dest="Makefile" src="core/root.mk"/>
   </project>
   <project name="gaia" path="gaia" remote="mozillaorg" revision="b2g-ota"/>
-  <project name="gecko" path="gecko" remote="mozillaorg" revision="b2g-ota"/>
+  <project name="gecko-dev" path="gecko" remote="mozorg_int" revision="b2g-ota"/>
   <project name="fake-libdvm" path="dalvik" remote="b2g" revision="b2g-ota"/>
   
   <project name="gonk-misc" path="gonk-misc" remote="b2g" revision="b2g-ota"/>

--- a/emulator-l.xml
+++ b/emulator-l.xml
@@ -10,13 +10,14 @@
   <remote fetch="git://github.com/apitrace/" name="apitrace"/>
   <remote fetch="git://codeaurora.org/" name="caf"/>
   <remote fetch="https://git.mozilla.org/releases" name="mozillaorg"/>
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
 
   <!-- B2G specific things. -->
   <project name="platform_build" path="build" remote="b2g" revision="c9d4fe680662ee44a4bdea42ae00366f5df399cf">
     <copyfile dest="Makefile" src="core/root.mk"/>
   </project>
   <project name="gaia" path="gaia" remote="mozillaorg" revision="b2g-ota"/>
-  <project name="gecko" path="gecko" remote="mozillaorg" revision="b2g-ota"/>
+  <project name="gecko-dev" path="gecko" remote="mozorg_int" revision="b2g-ota"/>
   <project name="fake-libdvm" path="dalvik" remote="b2g" revision="b2g-ota"/>
   
   <project name="gonk-misc" path="gonk-misc" remote="b2g" revision="b2g-ota"/>

--- a/emulator.xml
+++ b/emulator.xml
@@ -7,12 +7,13 @@
   <remote fetch="git://codeaurora.org/" name="caf"/>
   <remote fetch="git://github.com/mozilla/" name="mozilla"/>
   <remote fetch="https://git.mozilla.org/releases" name="mozillaorg"/>
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
 
   <default remote="caf" revision="refs/tags/android-4.0.4_r2.1" sync-j="4"/>
 
   <!-- Gecko and Gaia -->
   <project name="gaia.git" path="gaia" remote="mozillaorg" revision="b2g-ota"/>
-  <project name="gecko.git" path="gecko" remote="mozillaorg" revision="b2g-ota"/>
+  <project name="gecko-dev" path="gecko" remote="mozorg_int" revision="b2g-ota"/>
 
   <!-- Gonk-specific things and forks -->
   <project name="platform_bionic" path="bionic" remote="b2g" revision="e2b3733ba3fa5e3f404e983d2e4142b1f6b1b846"/>

--- a/flame-kk.xml
+++ b/flame-kk.xml
@@ -10,13 +10,14 @@
   <remote fetch="git://github.com/apitrace/" name="apitrace"/>
   <remote fetch="git://codeaurora.org/" name="caf"/>
   <remote fetch="https://git.mozilla.org/releases" name="mozillaorg"/>
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
 
   <!-- B2G specific things. -->
   <project name="platform_build" path="build" remote="b2g" revision="8d83715f08b7849f16a0dfc88f78d5c3a89c0a54">
     <copyfile dest="Makefile" src="core/root.mk"/>
   </project>
   <project name="gaia" path="gaia" remote="mozillaorg" revision="b2g-ota"/>
-  <project name="gecko" path="gecko" remote="mozillaorg" revision="b2g-ota"/>
+  <project name="gecko-dev" path="gecko" remote="mozorg_int" revision="b2g-ota"/>
   <project name="fake-libdvm" path="dalvik" remote="b2g" revision="b2g-ota"/>
   <project name="fake-qemu-kernel" path="prebuilts/qemu-kernel" remote="b2g" revision="b2g-ota"/>
   <project name="gonk-misc" path="gonk-misc" remote="b2g" revision="b2g-ota"/>

--- a/flatfish.xml
+++ b/flatfish.xml
@@ -6,6 +6,7 @@
   <remote fetch="git://codeaurora.org/" name="caf"/>
   <remote fetch="https://git.mozilla.org/releases" name="mozillaorg"/>
   <remote fetch="https://github.com/flatfish-fox/" name="allwinner"/>
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
 
   <default remote="aosp" revision="refs/tags/android-4.2.2_r1" sync-j="4"/>
 
@@ -15,7 +16,7 @@
   </project>
   <project name="fake-libdvm" path="dalvik" remote="b2g" revision="b2g-ota"/>
   <project name="gaia" path="gaia" remote="mozillaorg" revision="b2g-ota"/>
-  <project name="gecko.git" path="gecko" remote="mozillaorg" revision="b2g-ota"/>
+  <project name="gecko-dev" path="gecko" remote="mozorg_int" revision="b2g-ota"/>
   <project name="gonk-misc" path="gonk-misc" remote="b2g" revision="b2g-ota"/>
   <project name="rilproxy" path="rilproxy" remote="b2g" revision="b2g-ota"/>
   <project name="moztt" path="external/moztt" remote="b2g" revision="b2g-ota"/>

--- a/galaxy-nexus.xml
+++ b/galaxy-nexus.xml
@@ -7,6 +7,7 @@
   <remote name="linaro" fetch="http://android.git.linaro.org/git-ro/" />
   <remote name="mozilla" fetch="git://github.com/mozilla/" />
   <remote name="mozillaorg"  fetch="https://git.mozilla.org/releases" />
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
 
   <default revision="refs/tags/android-4.0.4_r2.1"
            remote="linaro"
@@ -14,7 +15,7 @@
 
   <!-- Gecko and Gaia -->
   <project path="gaia" name="gaia.git" remote="mozillaorg" revision="b2g-ota" />
-  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="master" />
+  <project path="gecko" name="gecko-dev" remote="mozorg_int" revision="b2g-ota" />
 
   <!-- Gonk-specific things and forks -->
   <project path="bionic" name="platform_bionic" remote="b2g" revision="b2g-4.0.4_r2.1" />

--- a/galaxy-s2.xml
+++ b/galaxy-s2.xml
@@ -11,6 +11,7 @@
 	  fetch="git://github.com/mozilla/" />
   <remote name="mozillaorg"
       fetch="https://git.mozilla.org/releases" />
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
   <remote name="apitrace" fetch="git://github.com/apitrace/" />
   <default revision="refs/tags/android-4.0.4_r1.2"
            remote="linaro"
@@ -22,7 +23,7 @@
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
   <project path="gaia" name="gaia.git" remote="mozillaorg" revision="b2g-ota" />
-  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="master" />
+  <project path="gecko" name="gecko-dev" remote="mozorg_int" revision="master" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />

--- a/hamachi.xml
+++ b/hamachi.xml
@@ -11,6 +11,7 @@
           fetch="git://codeaurora.org/" />
   <remote name="mozillaorg"
           fetch="https://git.mozilla.org/releases" />
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
   <remote name="apitrace" fetch="git://github.com/apitrace/" />
   <default revision="b2g/ics_strawberry"
            remote="caf"
@@ -22,7 +23,7 @@
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
   <project path="gaia" name="gaia.git" remote="mozillaorg" revision="b2g-ota" />
-  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="master" />
+  <project path="gecko" name="gecko-dev" remote="mozorg_int" revision="master" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="librecovery" name="librecovery" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />

--- a/helix.xml
+++ b/helix.xml
@@ -11,6 +11,7 @@
           fetch="git://codeaurora.org/" />
   <remote name="mozillaorg"
           fetch="https://git.mozilla.org/releases" />
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
   <default revision="b2g/ics_strawberry"
            remote="caf"
            sync-j="4" />
@@ -21,7 +22,7 @@
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master"/>
   <project path="gaia" name="gaia.git" remote="mozillaorg" revision="b2g-ota"/>
-  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="master"/>
+  <project path="gecko" name="gecko-dev" remote="mozorg_int" revision="b2g-ota"/>
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master"/>
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master"/>
   <project path="librecovery" name="librecovery" remote="b2g" revision="master"/>

--- a/keon.xml
+++ b/keon.xml
@@ -7,6 +7,7 @@
   <remote fetch="git://android.git.linaro.org/" name="linaro"/>
   <remote name="QRD" fetch="git://codeaurora.org/quic/qrd-android" />
   <remote name="apitrace" fetch="git://github.com/apitrace/" />
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
   <default remote="QRD" revision="ics_master_qrd_101" sync-j="9"/>
 
   <!-- Gonk specific things and forks -->
@@ -15,7 +16,7 @@
   </project>
   <project name="fake-dalvik" path="dalvik" remote="b2g" revision="master"/>
   <project name="releases/gaia.git" path="gaia" remote="mozillaorg" revision="b2g-ota" />
-  <project name="releases/gecko.git" path="gecko" remote="mozillaorg" revision="master" />
+  <project name="gecko-dev" path="gecko" remote="mozorg_int" revision="master" />
   <project name="gonk-misc" path="gonk-misc" remote="b2g" revision="master"/>
   <project name="rilproxy" path="rilproxy" remote="b2g" revision="master"/>
   <project name="librecovery" path="librecovery" remote="b2g" revision="master"/>

--- a/nexus-4-kk.xml
+++ b/nexus-4-kk.xml
@@ -9,6 +9,7 @@
   <remote fetch="git://github.com/mozilla/" name="mozilla"/>
   <remote fetch="git://github.com/apitrace/" name="apitrace"/>
   <remote fetch="git://codeaurora.org/" name="caf"/>
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
   <remote fetch="https://git.mozilla.org/releases" name="mozillaorg"/>
 
   <!-- B2G specific things. -->
@@ -16,7 +17,7 @@
     <copyfile dest="Makefile" src="core/root.mk"/>
   </project>
   <project name="gaia" path="gaia" remote="mozillaorg" revision="b2g-ota"/>
-  <project name="gecko" path="gecko" remote="mozillaorg" revision="b2g-ota"/>
+  <project name="gecko-dev" path="gecko" remote="mozorg_int" revision="b2g-ota"/>
   <project name="fake-libdvm" path="dalvik" remote="b2g" revision="b2g-ota"/>
   <project name="fake-qemu-kernel" path="prebuilts/qemu-kernel" remote="b2g" revision="b2g-ota"/>
   <project name="gonk-misc" path="gonk-misc" remote="b2g" revision="b2g-ota"/>

--- a/nexus-5-l.xml
+++ b/nexus-5-l.xml
@@ -10,13 +10,14 @@
   <remote fetch="git://github.com/apitrace/" name="apitrace"/>
   <remote fetch="git://codeaurora.org/" name="caf"/>
   <remote fetch="https://git.mozilla.org/releases" name="mozillaorg"/>
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
 
   <!-- B2G specific things. -->
   <project name="platform_build" path="build" remote="b2g" revision="c9d4fe680662ee44a4bdea42ae00366f5df399cf">
     <copyfile dest="Makefile" src="core/root.mk"/>
   </project>
   <project name="gaia" path="gaia" remote="mozillaorg" revision="b2g-ota"/>
-  <project name="gecko" path="gecko" remote="mozillaorg" revision="b2g-ota"/>
+  <project name="gecko-dev" path="gecko" remote="mozorg_int" revision="b2g-ota"/>
   <project name="fake-libdvm" path="dalvik" remote="b2g" revision="b2g-ota"/>
   <project name="fake-qemu-kernel" path="prebuilts/qemu-kernel" remote="b2g" revision="b2g-ota"/>
   <project name="gonk-misc" path="gonk-misc" remote="b2g" revision="b2g-ota"/>

--- a/nexus-5.xml
+++ b/nexus-5.xml
@@ -9,6 +9,7 @@
   <remote fetch="git://github.com/mozilla/" name="mozilla"/>
   <remote fetch="git://github.com/apitrace/" name="apitrace"/>
   <remote fetch="git://codeaurora.org/" name="caf"/>
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
   <remote fetch="https://git.mozilla.org/releases" name="mozillaorg"/>
 
   <!-- B2G specific things. -->
@@ -16,7 +17,7 @@
     <copyfile dest="Makefile" src="core/root.mk"/>
   </project>
   <project name="gaia" path="gaia" remote="mozillaorg" revision="b2g-ota"/>
-  <project name="gecko" path="gecko" remote="mozillaorg" revision="b2g-ota"/>
+  <project name="gecko-dev" path="gecko" remote="mozorg_int" revision="b2g-ota"/>
   <project name="fake-libdvm" path="dalvik" remote="b2g" revision="b2g-ota"/>
   <project name="fake-qemu-kernel" path="prebuilts/qemu-kernel" remote="b2g" revision="b2g-ota"/>
   <project name="gonk-misc" path="gonk-misc" remote="b2g" revision="b2g-ota"/>

--- a/nexus-6-l.xml
+++ b/nexus-6-l.xml
@@ -8,6 +8,7 @@
   <remote fetch="git://github.com/mozilla-b2g/" name="b2g"/>
   <remote fetch="git://github.com/mozilla/" name="mozilla"/>
   <remote fetch="git://github.com/apitrace/" name="apitrace"/>
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
   <remote fetch="git://codeaurora.org/" name="caf"/>
   <remote fetch="https://git.mozilla.org/releases" name="mozillaorg"/>
 
@@ -16,7 +17,7 @@
     <copyfile dest="Makefile" src="core/root.mk"/>
   </project>
   <project name="gaia" path="gaia" remote="mozillaorg" revision="b2g-ota"/>
-  <project name="gecko" path="gecko" remote="mozillaorg" revision="b2g-ota"/>
+  <project name="gecko-dev" path="gecko" remote="mozorg_int" revision="b2g-ota"/>
   <project name="fake-libdvm" path="dalvik" remote="b2g" revision="b2g-ota"/>
   <project name="fake-qemu-kernel" path="prebuilts/qemu-kernel" remote="b2g" revision="b2g-ota"/>
   <project name="gonk-misc" path="gonk-misc" remote="b2g" revision="b2g-ota"/>

--- a/nexus-s-4g.xml
+++ b/nexus-s-4g.xml
@@ -9,6 +9,7 @@
            fetch="http://android.git.linaro.org/git-ro/" />
   <remote name="mozilla"
 	  fetch="git://github.com/mozilla/" />
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
   <remote name="mozillaorg"
       fetch="https://git.mozilla.org/releases" />
   <remote name="apitrace" fetch="git://github.com/apitrace/" />
@@ -22,7 +23,7 @@
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
   <project path="gaia" name="gaia.git" remote="mozillaorg" revision="b2g-ota" />
-  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="master" />
+  <project path="gecko" name="gecko-dev" remote="mozorg_int" revision="master" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />

--- a/nexus-s.xml
+++ b/nexus-s.xml
@@ -9,6 +9,7 @@
           fetch="git://codeaurora.org/" />
   <remote name="mozilla"
 	  fetch="git://github.com/mozilla/" />
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
   <remote name="mozillaorg"
       fetch="https://git.mozilla.org/releases" />
   <remote name="apitrace" fetch="git://github.com/apitrace/" />
@@ -22,7 +23,7 @@
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
   <project path="gaia" name="gaia.git" remote="mozillaorg" revision="b2g-ota" />
-  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="master" />
+  <project path="gecko" name="gecko-dev" remote="mozorg_int" revision="b2g-ota" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />

--- a/otoro.xml
+++ b/otoro.xml
@@ -11,6 +11,7 @@
 	  fetch="git://github.com/mozilla/" />
   <remote name="caf"
           fetch="git://codeaurora.org/" />
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
   <remote name="mozillaorg"
            fetch="https://git.mozilla.org/releases" />
   <remote name="apitrace" fetch="git://github.com/apitrace/" />
@@ -24,7 +25,7 @@
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
   <project path="gaia" name="gaia.git" remote="mozillaorg" revision="b2g-ota" />
-  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="master" />
+  <project path="gecko" name="gecko-dev" remote="mozorg_int" revision="b2g-ota" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="librecovery" name="librecovery" remote="b2g" revision="master" />

--- a/pandaboard.xml
+++ b/pandaboard.xml
@@ -9,6 +9,7 @@
            fetch="http://android.git.linaro.org/git-ro/" />
   <remote name="caf"
           fetch="git://codeaurora.org/" />
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
   <remote name="mozillaorg"
       fetch="https://git.mozilla.org/releases" />
   <remote name="apitrace" fetch="git://github.com/apitrace/" />
@@ -22,7 +23,7 @@
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
   <project path="gaia" name="gaia.git" remote="mozillaorg" revision="b2g-ota" />
-  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="master" />
+  <project path="gecko" name="gecko-dev" remote="mozillaorg" revision="b2g-ota" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="external/moztt" name="moztt" remote="b2g" revision="master" />

--- a/peak.xml
+++ b/peak.xml
@@ -7,6 +7,7 @@
   <remote fetch="git://android.git.linaro.org/" name="linaro"/>
   <remote name="QRD" fetch="git://codeaurora.org/quic/qrd-android"/>
   <remote name="apitrace" fetch="git://github.com/apitrace/" />
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
   <default remote="QRD" revision="ics_master_qrd_101" sync-j="9"/>
 
   <!-- Gonk specific things and forks -->
@@ -15,7 +16,7 @@
   </project>
   <project name="fake-dalvik" path="dalvik" remote="b2g" revision="master"/>
   <project name="gaia" path="gaia" remote="b2g" revision="b2g-ota"/>
-  <project name="releases/gecko.git" path="gecko" remote="mozillaorg" revision="master"/>
+  <project name="gecko-dev" path="gecko" remote="mozorg_int" revision="b2g-ota"/>
   <project name="gonk-misc" path="gonk-misc" remote="b2g" revision="master"/>
   <project name="rilproxy" path="rilproxy" remote="b2g" revision="master"/>
   <project name="librecovery" path="librecovery" remote="b2g" revision="master"/>

--- a/rpi.xml
+++ b/rpi.xml
@@ -9,6 +9,7 @@
            fetch="git://github.com/mozilla-b2g/" />
   <remote name="mozilla"
 	  fetch="git://github.com/mozilla/" />
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
   <remote name="mozillaorg"
           fetch="https://git.mozilla.org/releases" />
   <remote name="apitrace" fetch="git://github.com/apitrace/" />
@@ -23,7 +24,7 @@
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
   <project path="gaia" name="gaia.git" remote="mozillaorg" revision="b2g-ota" />
-  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="master" />
+  <project path="gecko" name="gecko-dev" remote="mozorg_int" revision="b2g-ota" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="librecovery" name="librecovery" remote="b2g" revision="master" />

--- a/shinano.xml
+++ b/shinano.xml
@@ -10,13 +10,14 @@
   <remote fetch="git://github.com/apitrace/" name="apitrace"/>
   <remote fetch="git://codeaurora.org/" name="caf"/>
   <remote fetch="https://git.mozilla.org/releases" name="mozillaorg"/>
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
 
   <!-- B2G specific things. -->
   <project name="platform_build" path="build" remote="b2g" revision="8d83715f08b7849f16a0dfc88f78d5c3a89c0a54">
     <copyfile dest="Makefile" src="core/root.mk"/>
   </project>
   <project name="gaia" path="gaia" remote="mozillaorg" revision="b2g-ota"/>
-  <project name="gecko" path="gecko" remote="mozillaorg" revision="b2g-ota"/>
+  <project name="gecko-dev" path="gecko" remote="mozorg_int" revision="b2g-ota"/>
   <project name="fake-libdvm" path="dalvik" remote="b2g" revision="b2g-ota"/>
   <project name="fake-qemu-kernel" path="prebuilts/qemu-kernel" remote="b2g" revision="b2g-ota"/>
   <project name="gonk-misc" path="gonk-misc" remote="b2g" revision="b2g-ota"/>

--- a/sony-aosp-l.xml
+++ b/sony-aosp-l.xml
@@ -4,6 +4,7 @@
 
   
 
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
   <remote fetch="https://android.googlesource.com/" name="aosp"/>
   <remote fetch="git://github.com/mozilla-b2g/" name="b2g"/>
   <remote fetch="git://github.com/mozilla/" name="mozilla"/>
@@ -16,7 +17,7 @@
     <copyfile dest="Makefile" src="core/root.mk"/>
   </project>
   <project name="gaia" path="gaia" remote="mozillaorg" revision="b2g-ota"/>
-  <project name="gecko" path="gecko" remote="mozillaorg" revision="b2g-ota"/>
+  <project name="gecko-dev" path="gecko" remote="mozorg_int" revision="b2g-ota"/>
   <project name="fake-libdvm" path="dalvik" remote="b2g" revision="b2g-ota"/>
   <project name="fake-qemu-kernel" path="prebuilts/qemu-kernel" remote="b2g" revision="b2g-ota"/>
   <project name="gonk-misc" path="gonk-misc" remote="b2g" revision="b2g-ota"/>

--- a/tarako.xml
+++ b/tarako.xml
@@ -4,6 +4,7 @@
   <remote fetch="git://github.com/mozilla-b2g/" name="b2g"/>
   <remote fetch="git://github.com/mozilla/" name="mozilla"/>
   <remote fetch="git://github.com/apitrace/" name="apitrace"/>
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
   <remote fetch="https://git.mozilla.org/releases" name="mozillaorg"/>
   <remote fetch="http://sprdsource.spreadtrum.com:8085/b2g" name="sprd-b2g"/>
   <default remote="sprd-aosp" revision="refs/tags/android-4.0.4_r2.1" sync-j="4"/>
@@ -14,7 +15,7 @@
   </project>
   <project name="fake-dalvik" path="dalvik" remote="b2g" revision="b2g-ota"/>
   <project name="gaia.git" path="gaia" remote="mozillaorg" revision="b2g-ota"/>
-  <project name="gecko.git" path="gecko" remote="mozillaorg" revision="b2g-ota"/>
+  <project name="gecko-dev" path="gecko" remote="mozorg_int" revision="b2g-ota"/>
   <project name="gonk-misc" path="gonk-misc" remote="b2g" revision="b2g-ota"/>
   <project name="rilproxy" path="rilproxy" remote="b2g" revision="b2g-ota"/>
   <project name="librecovery" path="librecovery" remote="b2g" revision="b2g-ota"/>

--- a/vixen.xml
+++ b/vixen.xml
@@ -4,6 +4,7 @@
   <remote fetch="git://github.com/mozilla-b2g/" name="b2g"/>
   <remote fetch="git://github.com/apitrace/" name="apitrace"/>
   <remote fetch="https://git.mozilla.org/releases" name="mozillaorg"/>
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
   <remote fetch="https://github.com/apc-io" name="apc-io"/>
 
   <default remote="aosp" revision="refs/tags/android-4.2.2_r1" sync-j="4"/>
@@ -14,7 +15,7 @@
   </project>
   <project name="fake-libdvm" path="dalvik" remote="b2g" revision="b2g-ota"/>
   <project name="gaia" path="gaia" remote="mozillaorg" revision="b2g-ota"/>
-  <project name="gecko.git" path="gecko" remote="mozillaorg" revision="b2g-ota"/>
+  <project name="gecko-dev" path="gecko" remote="mozorg_int" revision="b2g-ota"/>
   <project name="gonk-misc" path="gonk-misc" remote="b2g" revision="b2g-ota"/>
   <project name="rilproxy" path="rilproxy" remote="b2g" revision="b2g-ota"/>
   <project name="moztt" path="external/moztt" remote="b2g" revision="b2g-ota"/>

--- a/wasabi.xml
+++ b/wasabi.xml
@@ -9,6 +9,7 @@
           fetch="git://github.com/mozilla/" />
   <remote name="caf"
           fetch="git://codeaurora.org/" />
+  <remote fetch="https://git.mozilla.org/integration" name="mozorg_int"/>
   <remote name="mozillaorg"
           fetch="https://git.mozilla.org/releases" />
   <remote name="apitrace" fetch="git://github.com/apitrace/" />
@@ -22,7 +23,7 @@
   </project>
   <project path="dalvik" name="fake-dalvik" remote="b2g" revision="master" />
   <project path="gaia" name="gaia.git" remote="mozillaorg" revision="b2g-ota" />
-  <project path="gecko" name="gecko.git" remote="mozillaorg" revision="master" />
+  <project path="gecko" name="gecko-dev" remote="mozorg_int" revision="b2g-ota" />
   <project path="gonk-misc" name="gonk-misc" remote="b2g" revision="master" />
   <project path="rilproxy" name="rilproxy" remote="b2g" revision="master" />
   <project path="librecovery" name="librecovery" remote="b2g" revision="master" />


### PR DESCRIPTION
manifest is pointing to a nonexisiting repo for gecko; local building is broken without a point to the right location.

based on an irc conversation between hal and fabrice, here's a patch.
