### PR TITLE
Bug 1236503: Fetch repositories for galaxy-nexus from CAF

### DIFF
--- a/galaxy-nexus.xml
+++ b/galaxy-nexus.xml
@@ -4,7 +4,7 @@
   <include name="base.xml"/>
 
   <default revision="refs/tags/android-4.0.4_r2.1"
-           remote="linaro"
+           remote="caf"
            sync-j="4" />
 
   <!-- Gonk-specific things and forks -->


### PR DESCRIPTION
CAF is considered more reliably and faster than Linaro, so we now fetch
repositories for galaxy-nexus by default from CAF.