### PR TITLE
Bug 1196221: Clone libfdio for all targets

### DIFF
--- a/base-jb.xml
+++ b/base-jb.xml
@@ -119,7 +119,6 @@
   <project name="platform_system_bluetoothd" path="system/bluetoothd" remote="b2g" revision="master"/>
   <project name="platform_system_core" path="system/core" remote="b2g" revision="b2g-4.3_r2.1"/>
   <project name="platform/system/extras" path="system/extras"/>
-  <project name="platform_system_libfdio" path="system/libfdio" remote="b2g" revision="master"/>
   <project name="platform/system/media" path="system/media"/>
   <project name="platform/system/netd" path="system/netd"/>
   <project name="platform/system/security" path="system/security"/>

--- a/base-kk.xml
+++ b/base-kk.xml
@@ -114,7 +114,6 @@
   <project name="platform_system_bluetoothd" path="system/bluetoothd" remote="b2g" revision="master"/>
   <project name="platform/system/extras" path="system/extras"/>
   <project name="platform/system/media" path="system/media"/>
-  <project name="platform_system_libfdio" path="system/libfdio" remote="b2g" revision="master"/>
   <project name="platform/system/netd" path="system/netd"/>
   <project name="platform/system/security" path="system/security"/>
   <project name="platform/system/vold" path="system/vold"/>

--- a/base-l.xml
+++ b/base-l.xml
@@ -132,7 +132,6 @@
   <project name="platform_system_bluetoothd" path="system/bluetoothd" remote="b2g" revision="master"/>
   <project name="platform/system/core" path="system/core"/>
   <project name="platform/system/extras" path="system/extras"/>
-  <project name="platform_system_libfdio" path="system/libfdio" remote="b2g" revision="master"/>
   <project name="platform/system/media" path="system/media"/>
   <project name="platform/system/netd" path="system/netd"/>
   <project name="platform/system/security" path="system/security"/>

--- a/base.xml
+++ b/base.xml
@@ -23,6 +23,7 @@
   <project name="gonk-misc" path="gonk-misc" remote="b2g" revision="master" />
   <project name="moztt" path="external/moztt" remote="b2g" revision="master"/>
   <project name="platform_hardware_libhardware_moz" path="hardware/libhardware_moz" remote="b2g" revision="master"/>
+  <project name="platform_system_libfdio" path="system/libfdio" remote="b2g" revision="master"/>
   <project name="platform_system_libpdu" path="system/libpdu" remote="b2g" revision="master"/>
   <project name="platform_system_sensorsd" path="system/sensorsd" remote="b2g" revision="master"/>
 

--- a/flatfish.xml
+++ b/flatfish.xml
@@ -111,7 +111,6 @@
   <project path="system/bluetoothd" name="platform_system_bluetoothd" remote="b2g" revision="master"/>
   <project path="system/core" name="platform_system_core" remote="b2g" revision="b2g-4.2.2_r1"/>
   <project path="system/extras" name="platform/system/extras"/>
-  <project path="system/libfdio" name="platform_system_libfdio" remote="b2g" revision="master"/>
   <project path="system/media" name="platform/system/media"/>
   <project path="system/netd" name="platform/system/netd"/>
   <project path="system/security" name="platform/system/security"/>

--- a/vixen.xml
+++ b/vixen.xml
@@ -106,7 +106,6 @@
   <project path="prebuilts/tools" name="platform/prebuilts/tools"/>
   <project path="system/bluetooth" name="platform/system/bluetooth"/>
   <project path="system/bluetoothd" name="platform_system_bluetoothd" remote="b2g" revision="master"/>
-  <project path="system/libfdio" name="platform_system_libfdio" remote="b2g" revision="master"/>
   <project path="system/security" name="platform/system/security"/>
 
   <!-- Vixen things -->


### PR DESCRIPTION
Sensorsd uses libfdio for it's event loop. The library has to be present
for all targets.