### PR TITLE
Bug 1294725 - Fairphone 2 needs special caf repo r=gerard-majax

### DIFF
--- a/fairphone2.xml
+++ b/fairphone2.xml
@@ -4,6 +4,8 @@
   <default remote="caf" revision="LA.BF.1.1.1_rb1.18" sync-j="4"/>
 
   <!-- Fairphone repos with specific changes -->
+  <remove-project name="platform_frameworks_native"/>  
+  <project name="platform_frameworks_native" path="frameworks/native" revision="b2g-fp2" />
   <project name="codeaurora_kernel_msm" path="kernel" remote="b2g" revision="b2g-msm-fairphone2-3.4-lollipop" />
   <remove-project name="platform_system_core" />
   <project groups="pdk" name="platform_system_core" path="system/core" remote="b2g" revision="b2g-fp2-sibon" />


### PR DESCRIPTION
Instead of doing this manualy:
cd frameworks/native && git checkout -b caf_atomic_cpp
caf/LA.BF.1.1.1_rb1.18 && curl -L
https://github.com/mozilla-b2g/platform_frameworks_native/pull/1.patch | git
am && cd ~/B2G
./repo sync
The caf/LA.BF.1.1.1_rb1.18 got forked to b2g-fp2 branch
- tested 25. Aug. 2016