### PR TITLE
Pin Gecko to last known good commit

### DIFF
--- a/base.xml
+++ b/base.xml
@@ -17,7 +17,7 @@
     -->
 
   <project name="gaia" path="gaia" remote="b2g" revision="master" />
-  <project name="gecko-dev" path="gecko" remote="mozilla" revision="master" />
+  <project name="gecko-dev" path="gecko" remote="mozilla" revision="d1276b5b84e6cf7991c8e640b5e0ffffd54575a6" />
   <project name="gonk-misc" path="gonk-misc" remote="b2g" revision="master" />
   <project name="moztt" path="external/moztt" remote="b2g" revision="master"/>
   <project name="platform_hardware_libhardware_moz" path="hardware/libhardware_moz" remote="b2g" revision="master"/>


### PR DESCRIPTION
Gecko master isn't working anymore when you build the `emulator-l` target of B2G.
Pinning it to the last known good commit [1](https://github.com/mozilla/gecko-dev/commit/d1276b5b84e6cf7991c8e640b5e0ffffd54575a6).
